### PR TITLE
Add maintenance info metrics at server

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,20 +156,24 @@ The exporter returns the following metrics:
 
 #### Server
 
-| Metric                           | Description                                                      | Labels                                                                                                    |
-| ------                           | -----------                                                      | ------                                                                                                    |
-| sakuracloud_server_info          | A metric with a constant '1' value labeled by server information | `id`, `name`, `zone`, `cpus`, `disks`, `nics`, `memories`, `host`, `tags`, `description`                  |
-| sakuracloud_server_up            | If 1 the server is up and running, 0 otherwise                   | `id`, `name`, `zone`                                                                                      |
-| sakuracloud_server_cpus          | Number of server's vCPU cores                                    | `id`, `name`, `zone`                                                                                      |
-| sakuracloud_server_cpu_time      | Server's CPU time(unit: ms)                                      | `id`, `name`, `zone`                                                                                      |
-| sakuracloud_server_memories      | Size of server's memories(unit: GB)                              | `id`, `name`, `zone`                                                                                      |
-| sakuracloud_server_disk_info     | A metric with a constant '1' value labeled by disk information   | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`, `plan`, `interface`, `size`, `tags`, `description` |
-| sakuracloud_server_disk_read     | Disk's read bytes(unit: KBps)                                    | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`                                                     |
-| sakuracloud_server_disk_write    | Disk's write bytes(unit: KBps)                                   | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`                                                     |
-| sakuracloud_server_nic_info      | A metric with a constant '1' value labeled by nic information    | `id`, `name`, `zone`, `interface_id`, `index`, `upstream_type`, `upstream_id`, `upstream_name`            |
-| sakuracloud_server_nic_bandwidth | NIC's Bandwidth(unit: Mbps)                                      | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
-| sakuracloud_server_nic_receive   | NIC's receive bytes(unit: Kbps)                                  | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
-| sakuracloud_server_nic_send      | NIC's send bytes(unit: Kbps)                                     | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
+| Metric                                   | Description                                                           | Labels                                                                                                    |
+| ------                                   | -----------                                                           | ------                                                                                                    |
+| sakuracloud_server_info                  | A metric with a constant '1' value labeled by server information      | `id`, `name`, `zone`, `cpus`, `disks`, `nics`, `memories`, `host`, `tags`, `description`                  |
+| sakuracloud_server_up                    | If 1 the server is up and running, 0 otherwise                        | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_cpus                  | Number of server's vCPU cores                                         | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_cpu_time              | Server's CPU time(unit: ms)                                           | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_memories              | Size of server's memories(unit: GB)                                   | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_disk_info             | A metric with a constant '1' value labeled by disk information        | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`, `plan`, `interface`, `size`, `tags`, `description` |
+| sakuracloud_server_disk_read             | Disk's read bytes(unit: KBps)                                         | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`                                                     |
+| sakuracloud_server_disk_write            | Disk's write bytes(unit: KBps)                                        | `id`, `name`, `zone`, `disk_id`, `disk_name`, `index`                                                     |
+| sakuracloud_server_nic_info              | A metric with a constant '1' value labeled by nic information         | `id`, `name`, `zone`, `interface_id`, `index`, `upstream_type`, `upstream_id`, `upstream_name`            |
+| sakuracloud_server_nic_bandwidth         | NIC's Bandwidth(unit: Mbps)                                           | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
+| sakuracloud_server_nic_receive           | NIC's receive bytes(unit: Kbps)                                       | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
+| sakuracloud_server_nic_send              | NIC's send bytes(unit: Kbps)                                          | `id`, `name`, `zone`, `interface_id`, `index`                                                             |
+| sakuracloud_server_maintenance_info      | A metric with a constant '1' value labeled by maintenance information | `id`, `name`, `zone`, `info_url`, `info_title`, `description`, `start_date`, `end_date`                   |
+| sakuracloud_server_maintenance_scheduled | If 1 the server has scheduled maintenance info, 0 otherwise           | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_maintenance_start     | Scheduled maintenance start time in seconds since epoch (1970)        | `id`, `name`, `zone`                                                                                      |
+| sakuracloud_server_maintenance_end       | Scheduled maintenance end time in seconds since epoch (1970)          | `id`, `name`, `zone`                                                                                      |
 
 #### ProxyLB
 

--- a/iaas/server.go
+++ b/iaas/server.go
@@ -13,6 +13,7 @@ type ServerClient interface {
 	MonitorCPU(zone string, serverID int64, end time.Time) (*sacloud.FlatMonitorValue, error)
 	MonitorDisk(zone string, diskID int64, end time.Time) (*DiskMetrics, error)
 	MonitorNIC(zone string, nicID int64, end time.Time) (*NICMetrics, error)
+	MaintenanceInfo(infoURL string) (*sacloud.NewsFeed, error)
 }
 
 func getServerClient(client *sakuraAPI.Client, zones []string) ServerClient {
@@ -73,4 +74,8 @@ func (s *serverClient) MonitorNIC(zone string, nicID int64, end time.Time) (*NIC
 	}
 
 	return queryNICMonitorValue(s.rawClient, zone, end, query)
+}
+
+func (s *serverClient) MaintenanceInfo(infoURL string) (*sacloud.NewsFeed, error) {
+	return s.rawClient.NewsFeed.GetFeedByURL(infoURL)
 }


### PR DESCRIPTION
(related: #15)

Add maintenance info metrics.

- `sakuracloud_server_maintenance_info`:  
A metric with a constant '1' value labeled by maintenance information

- `sakuracloud_server_maintenance_scheduled`:  
If 1 the server has scheduled maintenance info, 0 otherwise

- `sakuracloud_server_maintenance_start`:  
Scheduled maintenance start time in seconds since epoch (1970)

- `sakuracloud_server_maintenance_end`:  
Scheduled maintenance end time in seconds since epoch (1970)

Example:

```console
# HELP sakuracloud_server_maintenance_info A metric with a constant '1' value labeled by maintenance information
# TYPE sakuracloud_server_maintenance_info gauge
sakuracloud_server_maintenance_info{description=" [2019年1月1日]さくらのクラウド(一部のホストサーバ)[石狩第2ゾーン]",end_date="1562854200",id="123456789012",info_title="[メンテナンス] さくらのクラウド(一部のホストサーバ)でメンテナンスを実施します",info_url="http://support.sakura.ad.jp/mainte/mainteentry.php?id=11111",name="example",start_date="1562852700",zone="is1b"} 1

# HELP sakuracloud_server_maintenance_scheduled If 1 the server has scheduled maintenance info, 0 otherwise
# TYPE sakuracloud_server_maintenance_scheduled gauge
sakuracloud_server_maintenance_scheduled{id="123456789012",name="example",zone="is1b"} 1

# HELP sakuracloud_server_maintenance_start Scheduled maintenance start time in seconds since epoch (1970)
# TYPE sakuracloud_server_maintenance_start gauge
sakuracloud_server_maintenance_start{id="123456789012",name="example",zone="is1b"} 1.5628527e+09

# HELP sakuracloud_server_maintenance_end Scheduled maintenance end time in seconds since epoch (1970)
# TYPE sakuracloud_server_maintenance_end gauge
sakuracloud_server_maintenance_end{id="123456789012",name="example",zone="is1b"} 1.5628542e+0
```