### PR TITLE
Add no-collector.XXX flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ docker run -p 9542:9542 sacloud/sakuracloud_exporter
 
 | Flag / Environment Variable                  | Required | Default    | Description                 |
 | -------------------------------------------- | -------- | ---------- | -------------------------   |
-| `--fakemode` / `FAKE_MODE`                     |          |            | The file path of fake store. If set this, make enabled to fake-store-mode(powered by libsacloud's fake driver) |
+| `--fake-mode` / `FAKE_MODE`                     |          |            | The file path of fake store. If set this, make enabled to fake-store-mode(powered by libsacloud's fake driver) |
 
 Example fake store file(JSON) is here[examples/fake/generate-fake-store-json/example-fake-store.json].
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ docker run -p 9542:9542 sacloud/sakuracloud_exporter
 
 | Flag / Environment Variable                  | Required | Default    | Description                 |
 | -------------------------------------------- | -------- | ---------- | -------------------------   |
-| `fakemode` / `FAKE_MODE`                     |          |            | The file path of fake store. If set this, make enabled to fake-store-mode(powered by libsacloud's fake driver) |
+| `--fakemode` / `FAKE_MODE`                     |          |            | The file path of fake store. If set this, make enabled to fake-store-mode(powered by libsacloud's fake driver) |
 
 Example fake store file(JSON) is here[examples/fake/generate-fake-store-json/example-fake-store.json].
 

--- a/README.md
+++ b/README.md
@@ -37,25 +37,25 @@ $ docker run -p 9542:9542 sacloud/sakuracloud_exporter
 
 ### Flags
 
-| Flag / Environment Variable                  | Required | Default    | Description                                          |
-| -------------------------------------------- | -------- | ---------- | -------------------------                            |
-| `token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯        |            | API Key(Token)                                       |
-| `secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯        |            | API Key(Secret)                                      |
-| `ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                   |
-| `webaddr` / `WEBADDR`                        |          | `:9542`    | Exporter's listen address                            |
-| `webpath`/ `WEBPATH`                         |          | `/metrics` | Metrics request path                                 |
-| `no-collector.auto-backup`                   |          | `false`    | Disable the AutoBackup collector                     |
-| `no-collector.coupon`                        |          | `false`    | Disable the Coupon collector                         |
-| `no-collector.database`                      |          | `false`    | Disable the Database collector                       |
-| `no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector        |
-| `no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                   |
-| `no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                  |
-| `no-collector.nfs`                           |          | `false`    | Disable the NFS collector                            |
-| `no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector |
-| `no-collector.server`                        |          | `false`    | Disable the Server collector                         |
-| `no-collector.sim`                           |          | `false`    | Disable the SIM collector                            |
-| `no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                      |
-| `no-collector.zone`                          |          | `false`    | Disable the Zone collector                           |
+| Flag / Environment Variable                    | Required | Default    | Description                                          |
+| --------------------------------------------   | -------- | ---------- | -------------------------                            |
+| `--token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯        |            | API Key(Token)                                       |
+| `--secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯        |            | API Key(Secret)                                      |
+| `--ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                   |
+| `--webaddr` / `WEBADDR`                        |          | `:9542`    | Exporter's listen address                            |
+| `--webpath`/ `WEBPATH`                         |          | `/metrics` | Metrics request path                                 |
+| `--no-collector.auto-backup`                   |          | `false`    | Disable the AutoBackup collector                     |
+| `--no-collector.coupon`                        |          | `false`    | Disable the Coupon collector                         |
+| `--no-collector.database`                      |          | `false`    | Disable the Database collector                       |
+| `--no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector        |
+| `--no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                   |
+| `--no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                  |
+| `--no-collector.nfs`                           |          | `false`    | Disable the NFS collector                            |
+| `--no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector |
+| `--no-collector.server`                        |          | `false`    | Disable the Server collector                         |
+| `--no-collector.sim`                           |          | `false`    | Disable the SIM collector                            |
+| `--no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                      |
+| `--no-collector.zone`                          |          | `false`    | Disable the Zone collector                           |
 
 
 #### Flags for debug

--- a/README.md
+++ b/README.md
@@ -37,13 +37,26 @@ $ docker run -p 9542:9542 sacloud/sakuracloud_exporter
 
 ### Flags
 
-| Flag / Environment Variable                  | Required | Default    | Description                        |
-| -------------------------------------------- | -------- | ---------- | -------------------------          |
-| `token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯        |            | API Key(Token)                     |
-| `secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯        |            | API Key(Secret)                    |
-| `ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10) |
-| `webaddr` / `WEBADDR`                        |          | `:9542`    | Exporter's listen address          |
-| `webpath`/ `WEBPATH`                         |          | `/metrics` | Metrics request path               |
+| Flag / Environment Variable                  | Required | Default    | Description                                          |
+| -------------------------------------------- | -------- | ---------- | -------------------------                            |
+| `token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯        |            | API Key(Token)                                       |
+| `secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯        |            | API Key(Secret)                                      |
+| `ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                   |
+| `webaddr` / `WEBADDR`                        |          | `:9542`    | Exporter's listen address                            |
+| `webpath`/ `WEBPATH`                         |          | `/metrics` | Metrics request path                                 |
+| `no-collector.auto-backup`                   |          | `false`    | Disable the AutoBackup collector                     |
+| `no-collector.coupon`                        |          | `false`    | Disable the Coupon collector                         |
+| `no-collector.database`                      |          | `false`    | Disable the Database collector                       |
+| `no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector        |
+| `no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                   |
+| `no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                  |
+| `no-collector.nfs`                           |          | `false`    | Disable the NFS collector                            |
+| `no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector |
+| `no-collector.server`                        |          | `false`    | Disable the Server collector                         |
+| `no-collector.sim`                           |          | `false`    | Disable the SIM collector                            |
+| `no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                      |
+| `no-collector.zone`                          |          | `false`    | Disable the Zone collector                           |
+
 
 #### Flags for debug
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,15 +14,15 @@ const (
 
 // Config gets its content from env and passes it on to different packages
 type Config struct {
-	Trace     bool     `arg:"env:TRACE"`
-	Debug     bool     `arg:"env:DEBUG"`
-	FakeMode  string   `arg:"env:FAKE_MODE"`
-	Token     string   `arg:"required,env:SAKURACLOUD_ACCESS_TOKEN"`
-	Secret    string   `arg:"required,env:SAKURACLOUD_ACCESS_TOKEN_SECRET"`
+	Trace     bool     `arg:"env:TRACE" help:"Enable output of trace log of Sakura cloud API call"`
+	Debug     bool     `arg:"env:DEBUG" help:"Enable output of debug level log"`
+	FakeMode  string   `arg:"--fake-mode,env:FAKE_MODE" help:"File path to fetch/store fake data. If this flag is specified, enable fake-mode"`
+	Token     string   `arg:"required,env:SAKURACLOUD_ACCESS_TOKEN" help:"Token for using the SakuraCloud API"`
+	Secret    string   `arg:"required,env:SAKURACLOUD_ACCESS_TOKEN_SECRET" help:"Secret for using the SakuraCloud API"`
 	Zones     []string // TODO zones parameter is not implements.
 	WebAddr   string   `arg:"env:WEB_ADDR"`
 	WebPath   string   `arg:"env:WEB_PATH"`
-	RateLimit int      `arg:"env:SAKURACLOUD_RATE_LIMIT"`
+	RateLimit int      `arg:"env:SAKURACLOUD_RATE_LIMIT" help:"Rate limit per second for SakuraCloud API calls"`
 
 	NoCollectorAutoBackup    bool `arg:"--no-collector.auto-backup" help:"Disable the AutoBackup collector"`
 	NoCollectorCoupon        bool `arg:"--no-collector.coupon" help:"Disable the Coupon collector"`

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,19 @@ type Config struct {
 	WebAddr   string   `arg:"env:WEB_ADDR"`
 	WebPath   string   `arg:"env:WEB_PATH"`
 	RateLimit int      `arg:"env:SAKURACLOUD_RATE_LIMIT"`
+
+	NoCollectorAutoBackup    bool `arg:"--no-collector.auto-backup" help:"Disable the AutoBackup collector"`
+	NoCollectorCoupon        bool `arg:"--no-collector.coupon" help:"Disable the Coupon collector"`
+	NoCollectorDatabase      bool `arg:"--no-collector.database" help:"Disable the Database collector"`
+	NoCollectorInternet      bool `arg:"--no-collector.internet" help:"Disable the Internet(Switch+Router) collector"`
+	NoCollectorLoadBalancer  bool `arg:"--no-collector.load-balancer" help:"Disable the LoadBalancer collector"`
+	NoCollectorMobileGateway bool `arg:"--no-collector.mobile-gateway" help:"Disable the MobileGateway collector"`
+	NoCollectorNFS           bool `arg:"--no-collector.nfs" help:"Disable the NFS collector"`
+	NoCollectorProxyLB       bool `arg:"--no-collector.proxy-lb" help:"Disable the ProxyLB(Enhanced LoadBalancer) collector"`
+	NoCollectorServer        bool `arg:"--no-collector.server" help:"Disable the Server collector"`
+	NoCollectorSIM           bool `arg:"--no-collector.sim" help:"Disable the SIM collector"`
+	NoCollectorVPCRouter     bool `arg:"--no-collector.vpc-router" help:"Disable the VPCRouter collector"`
+	NoCollectorZone          bool `arg:"--no-collector.zone" help:"Disable the Zone collector"`
 }
 
 func InitConfig() (Config, error) {

--- a/main.go
+++ b/main.go
@@ -80,18 +80,42 @@ func main() {
 	r.MustRegister(errors)
 
 	// sakuracloud metrics
-	r.MustRegister(collector.NewAutoBackupCollector(ctx, logger, errors, client.AutoBackup))
-	r.MustRegister(collector.NewCouponCollector(ctx, logger, errors, client.Coupon))
-	r.MustRegister(collector.NewDatabaseCollector(ctx, logger, errors, client.Database))
-	r.MustRegister(collector.NewInternetCollector(ctx, logger, errors, client.Internet))
-	r.MustRegister(collector.NewLoadBalancerCollector(ctx, logger, errors, client.LoadBalancer))
-	r.MustRegister(collector.NewNFSCollector(ctx, logger, errors, client.NFS))
-	r.MustRegister(collector.NewMobileGatewayCollector(ctx, logger, errors, client.MobileGateway))
-	r.MustRegister(collector.NewProxyLBCollector(ctx, logger, errors, client.ProxyLB))
-	r.MustRegister(collector.NewServerCollector(ctx, logger, errors, client.Server))
-	r.MustRegister(collector.NewSIMCollector(ctx, logger, errors, client.SIM))
-	r.MustRegister(collector.NewVPCRouterCollector(ctx, logger, errors, client.VPCRouter))
-	r.MustRegister(collector.NewZoneCollector(ctx, logger, errors, client.Zone))
+	if !c.NoCollectorAutoBackup {
+		r.MustRegister(collector.NewAutoBackupCollector(ctx, logger, errors, client.AutoBackup))
+	}
+	if !c.NoCollectorCoupon {
+		r.MustRegister(collector.NewCouponCollector(ctx, logger, errors, client.Coupon))
+	}
+	if !c.NoCollectorDatabase {
+		r.MustRegister(collector.NewDatabaseCollector(ctx, logger, errors, client.Database))
+	}
+	if !c.NoCollectorInternet {
+		r.MustRegister(collector.NewInternetCollector(ctx, logger, errors, client.Internet))
+	}
+	if !c.NoCollectorLoadBalancer {
+		r.MustRegister(collector.NewLoadBalancerCollector(ctx, logger, errors, client.LoadBalancer))
+	}
+	if !c.NoCollectorNFS {
+		r.MustRegister(collector.NewNFSCollector(ctx, logger, errors, client.NFS))
+	}
+	if !c.NoCollectorMobileGateway {
+		r.MustRegister(collector.NewMobileGatewayCollector(ctx, logger, errors, client.MobileGateway))
+	}
+	if !c.NoCollectorProxyLB {
+		r.MustRegister(collector.NewProxyLBCollector(ctx, logger, errors, client.ProxyLB))
+	}
+	if !c.NoCollectorServer {
+		r.MustRegister(collector.NewServerCollector(ctx, logger, errors, client.Server))
+	}
+	if !c.NoCollectorSIM {
+		r.MustRegister(collector.NewSIMCollector(ctx, logger, errors, client.SIM))
+	}
+	if !c.NoCollectorVPCRouter {
+		r.MustRegister(collector.NewVPCRouterCollector(ctx, logger, errors, client.VPCRouter))
+	}
+	if !c.NoCollectorZone {
+		r.MustRegister(collector.NewZoneCollector(ctx, logger, errors, client.Zone))
+	}
 
 	http.Handle(c.WebPath,
 		promhttp.HandlerFor(r, promhttp.HandlerOpts{}),


### PR DESCRIPTION
fixes #2

This PR adds `no-collector.XXX` flags.

These flags can disable each collector.
Added flags are:

- `--no-collector.auto-backup`
- `--no-collector.coupon`   
- `--no-collector.database`  
- `--no-collector.internet`  
- `--no-collector.load-balancer`
- `--no-collector.mobile-gateway`
- `--no-collector.nfs`
- `--no-collector.proxy-lb`  
- `--no-collector.server`
- `--no-collector.sim`       
- `--no-collector.vpc-router`
- `--no-collector.zone`   
