### PR TITLE
Supports LocalRouter API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- '1.12.x'
+- '1.13.x'
 env:
   global:
   - PATH=/home/travis/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ docker run -p 9542:9542 sacloud/sakuracloud_exporter
 | `--no-collector.database`                      |          | `false`    | Disable the Database collector                       |
 | `--no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector        |
 | `--no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                   |
+| `--no-collector.local-router`                  |          | `false`    | Disable the LocalRouter collector                    |
 | `--no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                  |
 | `--no-collector.nfs`                           |          | `false`    | Disable the NFS collector                            |
 | `--no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector |
@@ -81,6 +82,7 @@ The exporter returns the following metrics:
 | [Database](#database)           | sakuracloud_database_*       |
 | [Switch+Router](#switchrouter)  | sakuracloud_internet_*       |
 | [LoadBalancer](#loadbalancer)   | sakuracloud_loadbalancer_*   |
+| [LocalRouter](#localrouter)     | sakuracloud_local_router_*   |
 | [MobileGateway](#mobilegateway) | sakuracloud_mobile_gateway_* |
 | [NFS](#nfs)                     | sakuracloud_nfs_*            |
 | [ProxyLB](#proxylb)             | sakuracloud_proxylb_*        |
@@ -152,6 +154,20 @@ The exporter returns the following metrics:
 | sakuracloud_loadbalancer_server_up         | If 1 the server is up and running, 0 otherwise                         | `id`, `name`, `zone`, `vip_index`, `vip`, `server_index`, `ipaddress`                                                   |
 | sakuracloud_loadbalancer_server_connection | Current connection count                                               | `id`, `name`, `zone`, `vip_index`, `vip`, `server_index`, `ipaddress`                                                   |
 | sakuracloud_loadbalancer_server_cps        | Connection count per second                                            | `id`, `name`, `zone`, `vip_index`, `vip`, `server_index`, `ipaddress`                                                   |
+
+#### LocalRouter
+
+| Metric                                     | Description                                                                            | Labels                                                                 |
+| ------                                     | -----------                                                                            | ------                                                                 |
+| sakuracloud_local_router_info              | A metric with a constant '1' value labeled by localRouter information                  | `id`, `name`, `tags`, `description`                                    |
+| sakuracloud_local_router_up                | If 1 the localRouter is up and running, 0 otherwise                                    | `id`, `name`                                                           |
+| sakuracloud_local_router_switch_info       | A metric with a constant '1' value labeled by localRouter connected switch information | `id`, `name`, `category`, `code`, `zone_id`                            |
+| sakuracloud_local_router_network_info      | A metric with a constant '1' value labeled by network information of the localRouter   | `id`, `name`, `vip`, `ipaddress1`, `ipaddress2`, `nw_mask_len`, `vrid` |
+| sakuracloud_local_router_static_route_info | A metric with a constant '1' value labeled by static route information                 | `id`, `name`, `route_index`, `prefix`, `next_hop`                      |
+| sakuracloud_local_router_peer_info         | A metric with a constant '1' value labeled by peer information                         | `id`, `name`, `peer_index`, `peer_id`, `enabled`, `description`        |
+| sakuracloud_local_router_peer_up           | If 1 the Peer is available, 0 otherwise                                                | `id`, `name`, `peer_index`, `peer_id`                                  |
+| sakuracloud_local_router_receive_per_sec   | Receive bytes per seconds                                                              | `id`, `name`                                                           |
+| sakuracloud_local_router_send_per_sec      | Send bytes per seconds                                                                 | `id`, `name`                                                           |
 
 #### MobileGateway
 

--- a/collector/local_router.go
+++ b/collector/local_router.go
@@ -1,0 +1,352 @@
+// Copyright 2019-2020 The sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"fmt"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/sakuracloud_exporter/iaas"
+)
+
+// LocalRouterCollector collects metrics about all localRouters.
+type LocalRouterCollector struct {
+	ctx    context.Context
+	logger log.Logger
+	errors *prometheus.CounterVec
+	client iaas.LocalRouterClient
+
+	Up              *prometheus.Desc
+	LocalRouterInfo *prometheus.Desc
+	SwitchInfo      *prometheus.Desc
+	NetworkInfo     *prometheus.Desc
+	PeerInfo        *prometheus.Desc
+	PeerUp          *prometheus.Desc
+	StaticRouteInfo *prometheus.Desc
+
+	ReceiveBytesPerSec *prometheus.Desc
+	SendBytesPerSec    *prometheus.Desc
+}
+
+// NewLocalRouterCollector returns a new LocalRouterCollector.
+func NewLocalRouterCollector(ctx context.Context, logger log.Logger, errors *prometheus.CounterVec, client iaas.LocalRouterClient) *LocalRouterCollector {
+	errors.WithLabelValues("local_router").Add(0)
+
+	localRouterLabels := []string{"id", "name"}
+	localRouterInfoLabels := append(localRouterLabels, "tags", "description")
+	localRouterSwitchInfoLabels := append(localRouterLabels, "category", "code", "zone_id")
+	localRouterServerNetworkInfoLabels := append(localRouterLabels, "vip", "ipaddress1", "ipaddress2", "nw_mask_len", "vrid")
+	localRouterPeerLabels := append(localRouterLabels, "peer_index", "peer_id")
+	localRouterPeerInfoLabels := append(localRouterPeerLabels, "enabled", "description")
+	localRouterStaticRouteInfoLabels := append(localRouterLabels, "route_index", "prefix", "next_hop")
+
+	return &LocalRouterCollector{
+		ctx:    ctx,
+		logger: logger,
+		errors: errors,
+		client: client,
+		Up: prometheus.NewDesc(
+			"sakuracloud_local_router_up",
+			"If 1 the LocalRouter is available, 0 otherwise",
+			localRouterLabels, nil,
+		),
+		LocalRouterInfo: prometheus.NewDesc(
+			"sakuracloud_local_router_info",
+			"A metric with a constant '1' value labeled by localRouter information",
+			localRouterInfoLabels, nil,
+		),
+		SwitchInfo: prometheus.NewDesc(
+			"sakuracloud_local_router_switch_info",
+			"A metric with a constant '1' value labeled by localRouter connected switch information",
+			localRouterSwitchInfoLabels, nil,
+		),
+		NetworkInfo: prometheus.NewDesc(
+			"sakuracloud_local_router_network_info",
+			"A metric with a constant '1' value labeled by network information of the localRouter",
+			localRouterServerNetworkInfoLabels, nil,
+		),
+		PeerInfo: prometheus.NewDesc(
+			"sakuracloud_local_router_peer_info",
+			"A metric with a constant '1' value labeled by peer information",
+			localRouterPeerInfoLabels, nil,
+		),
+		PeerUp: prometheus.NewDesc(
+			"sakuracloud_local_router_peer_up",
+			"If 1 the Peer is available, 0 otherwise",
+			localRouterPeerLabels, nil,
+		),
+		StaticRouteInfo: prometheus.NewDesc(
+			"sakuracloud_local_router_static_route_info",
+			"A metric with a constant '1' value labeled by static route information",
+			localRouterStaticRouteInfoLabels, nil,
+		),
+		ReceiveBytesPerSec: prometheus.NewDesc(
+			"sakuracloud_local_router_receive_per_sec",
+			"Receive bytes per seconds",
+			localRouterLabels, nil,
+		),
+		SendBytesPerSec: prometheus.NewDesc(
+			"sakuracloud_local_router_send_per_sec",
+			"Send bytes per seconds",
+			localRouterLabels, nil,
+		),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector.
+func (c *LocalRouterCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.Up
+	ch <- c.LocalRouterInfo
+	ch <- c.SwitchInfo
+	ch <- c.NetworkInfo
+	ch <- c.PeerInfo
+	ch <- c.PeerUp
+	ch <- c.StaticRouteInfo
+	ch <- c.ReceiveBytesPerSec
+	ch <- c.SendBytesPerSec
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *LocalRouterCollector) Collect(ch chan<- prometheus.Metric) {
+	localRouters, err := c.client.Find(c.ctx)
+	if err != nil {
+		c.errors.WithLabelValues("local_router").Add(1)
+		level.Warn(c.logger).Log(
+			"msg", "can't list localRouters",
+			"err", err,
+		)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(localRouters))
+
+	for i := range localRouters {
+		func(localRouter *sacloud.LocalRouter) {
+			defer wg.Done()
+
+			localRouterLabels := c.localRouterLabels(localRouter)
+
+			var up float64
+			if localRouter.Availability.IsAvailable() {
+				up = 1.0
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.Up,
+				prometheus.GaugeValue,
+				up,
+				localRouterLabels...,
+			)
+
+			c.collectLocalRouterInfo(ch, localRouter)
+			if localRouter.Switch != nil {
+				c.collectSwitchInfo(ch, localRouter)
+			}
+			if localRouter.Interface != nil {
+				c.collectNetworkInfo(ch, localRouter)
+			}
+
+			wg.Add(1)
+			go func() {
+				c.collectPeerInfo(ch, localRouter)
+				wg.Done()
+			}()
+
+			for i := range localRouter.StaticRoutes {
+				c.collectStaticRouteInfo(ch, localRouter, i)
+			}
+
+			if localRouter.Availability.IsAvailable() {
+				now := time.Now()
+
+				wg.Add(1)
+				go func() {
+					c.collectLocalRouterMetrics(ch, localRouter, now)
+					wg.Done()
+				}()
+			}
+
+		}(localRouters[i])
+	}
+
+	wg.Wait()
+}
+
+func (c *LocalRouterCollector) localRouterLabels(localRouter *sacloud.LocalRouter) []string {
+	return []string{
+		localRouter.ID.String(),
+		localRouter.Name,
+	}
+}
+
+func (c *LocalRouterCollector) collectLocalRouterInfo(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter) {
+	labels := append(c.localRouterLabels(localRouter),
+		flattenStringSlice(localRouter.Tags),
+		localRouter.Description,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.LocalRouterInfo,
+		prometheus.GaugeValue,
+		float64(1.0),
+		labels...,
+	)
+}
+
+func (c *LocalRouterCollector) collectSwitchInfo(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter) {
+	labels := append(c.localRouterLabels(localRouter),
+		localRouter.Switch.Category,
+		localRouter.Switch.Code,
+		localRouter.Switch.ZoneID,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.SwitchInfo,
+		prometheus.GaugeValue,
+		float64(1.0),
+		labels...,
+	)
+}
+
+func (c *LocalRouterCollector) collectNetworkInfo(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter) {
+	labels := append(c.localRouterLabels(localRouter),
+		localRouter.Interface.VirtualIPAddress,
+		localRouter.Interface.IPAddress[0],
+		localRouter.Interface.IPAddress[1],
+		fmt.Sprintf("%d", localRouter.Interface.NetworkMaskLen),
+		fmt.Sprintf("%d", localRouter.Interface.VRID),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.NetworkInfo,
+		prometheus.GaugeValue,
+		float64(1.0),
+		labels...,
+	)
+}
+
+func (c *LocalRouterCollector) collectPeerInfo(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter) {
+
+	//localRouterPeerLabels := append(localRouterLabels, "peer_index", "peer_id")
+	//localRouterPeerInfoLabels := append(localRouterPeerLabels, "enabled", "description")
+
+	healthStatus, err := c.client.Health(c.ctx, localRouter.ID)
+	if err != nil {
+		c.errors.WithLabelValues("local_router").Add(1)
+		level.Warn(c.logger).Log(
+			"msg", fmt.Sprintf("can't read health status of the localRouter[%s]", localRouter.ID.String()),
+			"err", err,
+		)
+		return
+	}
+
+	for i, peer := range localRouter.Peers {
+		peerStatus := c.getPeerStatus(healthStatus.Peers, peer.ID)
+		if peerStatus != nil {
+
+			labels := append(c.localRouterLabels(localRouter),
+				fmt.Sprintf("%d", i),
+				peer.ID.String(),
+			)
+
+			up := float64(1.0)
+			if strings.ToLower(string(peerStatus.Status)) != "up" {
+				up = 0
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.PeerUp,
+				prometheus.GaugeValue,
+				up,
+				labels...,
+			)
+
+			enabled := "0"
+			if peer.Enabled {
+				enabled = "1"
+			}
+			infoLabels := append(labels, enabled, peer.Description)
+			ch <- prometheus.MustNewConstMetric(
+				c.PeerInfo,
+				prometheus.GaugeValue,
+				float64(1.0),
+				infoLabels...,
+			)
+		}
+	}
+}
+
+func (c *LocalRouterCollector) getPeerStatus(peerStatuses []*sacloud.LocalRouterHealthPeer, peerID types.ID) *sacloud.LocalRouterHealthPeer {
+	for _, peer := range peerStatuses {
+		if peer.ID == peerID {
+			return peer
+		}
+	}
+	return nil
+}
+
+func (c *LocalRouterCollector) collectStaticRouteInfo(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter, staticRouteIndex int) {
+	labels := append(c.localRouterLabels(localRouter),
+		fmt.Sprintf("%d", staticRouteIndex),
+		localRouter.StaticRoutes[staticRouteIndex].Prefix,
+		localRouter.StaticRoutes[staticRouteIndex].NextHop,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.StaticRouteInfo,
+		prometheus.GaugeValue,
+		float64(1.0),
+		labels...,
+	)
+}
+
+func (c *LocalRouterCollector) collectLocalRouterMetrics(ch chan<- prometheus.Metric, localRouter *sacloud.LocalRouter, now time.Time) {
+
+	values, err := c.client.Monitor(c.ctx, localRouter.ID, now)
+	if err != nil {
+		c.errors.WithLabelValues("local_router").Add(1)
+		level.Warn(c.logger).Log(
+			"msg", fmt.Sprintf("can't get localRouter's metrics: LocalRouterID=%d", localRouter.ID),
+			"err", err,
+		)
+		return
+	}
+	if values == nil {
+		return
+	}
+
+	m := prometheus.MustNewConstMetric(
+		c.ReceiveBytesPerSec,
+		prometheus.GaugeValue,
+		values.ReceiveBytesPerSec*8, // byte per sec -> bps(bit)
+		c.localRouterLabels(localRouter)...,
+	)
+	ch <- prometheus.NewMetricWithTimestamp(values.Time, m)
+
+	m = prometheus.MustNewConstMetric(
+		c.SendBytesPerSec,
+		prometheus.GaugeValue,
+		values.SendBytesPerSec*8, // byte per sec -> bps(bit)
+		c.localRouterLabels(localRouter)...,
+	)
+	ch <- prometheus.NewMetricWithTimestamp(values.Time, m)
+}

--- a/collector/local_router_test.go
+++ b/collector/local_router_test.go
@@ -1,0 +1,354 @@
+// Copyright 2019-2020 The sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/sakuracloud_exporter/iaas"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+type dummyLocalRouterClient struct {
+	find       []*sacloud.LocalRouter
+	findErr    error
+	health     *sacloud.LocalRouterHealth
+	healthErr  error
+	monitor    *sacloud.MonitorLocalRouterValue
+	monitorErr error
+}
+
+func (d *dummyLocalRouterClient) Find(ctx context.Context) ([]*sacloud.LocalRouter, error) {
+	return d.find, d.findErr
+}
+
+func (d *dummyLocalRouterClient) Health(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	return d.health, d.healthErr
+}
+
+func (d *dummyLocalRouterClient) Monitor(ctx context.Context, id types.ID, end time.Time) (*sacloud.MonitorLocalRouterValue, error) {
+	return d.monitor, d.monitorErr
+}
+
+func TestLocalRouterCollector_Describe(t *testing.T) {
+	initLoggerAndErrors()
+	c := NewLocalRouterCollector(context.Background(), testLogger, testErrors, &dummyLocalRouterClient{})
+
+	descs := collectDescs(c)
+	require.Len(t, descs, len([]*prometheus.Desc{
+		c.Up,
+		c.LocalRouterInfo,
+		c.SwitchInfo,
+		c.NetworkInfo,
+		c.PeerInfo,
+		c.PeerUp,
+		c.StaticRouteInfo,
+		c.ReceiveBytesPerSec,
+		c.SendBytesPerSec,
+	}))
+}
+
+func TestLocalRouterCollector_Collect(t *testing.T) {
+	initLoggerAndErrors()
+	c := NewLocalRouterCollector(context.Background(), testLogger, testErrors, nil)
+	monitorTime := time.Unix(1, 0)
+
+	cases := []struct {
+		name           string
+		in             iaas.LocalRouterClient
+		wantLogs       []string
+		wantErrCounter float64
+		wantMetrics    []*collectedMetric
+	}{
+		{
+			name: "collector returns error",
+			in: &dummyLocalRouterClient{
+				findErr: errors.New("dummy"),
+			},
+			wantLogs:       []string{`level=warn msg="can't list localRouters" err=dummy`},
+			wantErrCounter: 1,
+			wantMetrics:    nil,
+		},
+		{
+			name:        "empty result",
+			in:          &dummyLocalRouterClient{},
+			wantMetrics: nil,
+		},
+		{
+			name: "a local router",
+			in: &dummyLocalRouterClient{
+				find: []*sacloud.LocalRouter{
+					{
+						ID:           101,
+						Name:         "local-router",
+						Tags:         types.Tags{"tag1", "tag2"},
+						Description:  "desc",
+						Availability: types.Availabilities.Available,
+						Switch: &sacloud.LocalRouterSwitch{
+							Code:     "201",
+							Category: "cloud",
+							ZoneID:   "is1a",
+						},
+						Interface: &sacloud.LocalRouterInterface{
+							VirtualIPAddress: "192.0.2.1",
+							IPAddress:        []string{"192.0.2.11", "192.0.2.12"},
+							NetworkMaskLen:   24,
+							VRID:             100,
+						},
+						StaticRoutes: []*sacloud.LocalRouterStaticRoute{
+							{
+								Prefix:  "10.0.0.0/24",
+								NextHop: "192.0.2.101",
+							},
+							{
+								Prefix:  "10.0.1.0/24",
+								NextHop: "192.0.2.102",
+							},
+						},
+					},
+				},
+			},
+			wantMetrics: []*collectedMetric{
+				{
+					desc: c.Up,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":   "101",
+						"name": "local-router",
+					}),
+				},
+				{
+					desc: c.LocalRouterInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"tags":        ",tag1,tag2,",
+						"description": "desc",
+					}),
+				},
+				{
+					desc: c.SwitchInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":       "101",
+						"name":     "local-router",
+						"code":     "201",
+						"category": "cloud",
+						"zone_id":  "is1a",
+					}),
+				},
+				{
+					desc: c.NetworkInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"vip":         "192.0.2.1",
+						"ipaddress1":  "192.0.2.11",
+						"ipaddress2":  "192.0.2.12",
+						"nw_mask_len": "24",
+						"vrid":        "100",
+					}),
+				},
+				{
+					desc: c.StaticRouteInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"route_index": "0",
+						"prefix":      "10.0.0.0/24",
+						"next_hop":    "192.0.2.101",
+					}),
+				},
+				{
+					desc: c.StaticRouteInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"route_index": "1",
+						"prefix":      "10.0.1.0/24",
+						"next_hop":    "192.0.2.102",
+					}),
+				},
+			},
+		},
+		{
+			name: "a local router with peers",
+			in: &dummyLocalRouterClient{
+				find: []*sacloud.LocalRouter{
+					{
+						ID:           101,
+						Name:         "local-router",
+						Tags:         types.Tags{"tag1", "tag2"},
+						Description:  "desc",
+						Availability: types.Availabilities.Available,
+						Peers: []*sacloud.LocalRouterPeer{
+							{
+								ID:          201,
+								SecretKey:   "dummy",
+								Enabled:     true,
+								Description: "desc201",
+							},
+							{
+								ID:          202,
+								SecretKey:   "dummy",
+								Enabled:     true,
+								Description: "desc202",
+							},
+						},
+					},
+				},
+				health: &sacloud.LocalRouterHealth{
+					Peers: []*sacloud.LocalRouterHealthPeer{
+						{
+							ID:     201,
+							Status: "UP",
+							Routes: []string{"10.0.0.0/24"},
+						},
+						{
+							ID:     202,
+							Status: "UP",
+							Routes: []string{"10.0.1.0/24"},
+						},
+					},
+				},
+			},
+			wantMetrics: []*collectedMetric{
+				{
+					desc: c.Up,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":   "101",
+						"name": "local-router",
+					}),
+				},
+				{
+					desc: c.LocalRouterInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"tags":        ",tag1,tag2,",
+						"description": "desc",
+					}),
+				},
+				{
+					desc: c.PeerUp,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":         "101",
+						"name":       "local-router",
+						"peer_index": "0",
+						"peer_id":    "201",
+					}),
+				},
+				{
+					desc: c.PeerUp,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":         "101",
+						"name":       "local-router",
+						"peer_index": "1",
+						"peer_id":    "202",
+					}),
+				},
+				{
+					desc: c.PeerInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"peer_index":  "0",
+						"peer_id":     "201",
+						"enabled":     "1",
+						"description": "desc201",
+					}),
+				},
+				{
+					desc: c.PeerInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"peer_index":  "1",
+						"peer_id":     "202",
+						"enabled":     "1",
+						"description": "desc202",
+					}),
+				},
+			},
+		},
+		{
+			name: "a local router with activities",
+			in: &dummyLocalRouterClient{
+				find: []*sacloud.LocalRouter{
+					{
+						ID:           101,
+						Name:         "local-router",
+						Tags:         types.Tags{"tag1", "tag2"},
+						Description:  "desc",
+						Availability: types.Availabilities.Available,
+					},
+				},
+				monitor: &sacloud.MonitorLocalRouterValue{
+					Time:               monitorTime,
+					ReceiveBytesPerSec: 10,
+					SendBytesPerSec:    20,
+				},
+			},
+			wantMetrics: []*collectedMetric{
+				{
+					desc: c.Up,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":   "101",
+						"name": "local-router",
+					}),
+				},
+				{
+					desc: c.LocalRouterInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "local-router",
+						"tags":        ",tag1,tag2,",
+						"description": "desc",
+					}),
+				},
+				{
+					desc: c.ReceiveBytesPerSec,
+					metric: createGaugeWithTimestamp(10*8, map[string]string{
+						"id":   "101",
+						"name": "local-router",
+					}, monitorTime),
+				},
+				{
+					desc: c.SendBytesPerSec,
+					metric: createGaugeWithTimestamp(20*8, map[string]string{
+						"id":   "101",
+						"name": "local-router",
+					}, monitorTime),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		initLoggerAndErrors()
+		c.logger = testLogger
+		c.errors = testErrors
+		c.client = tc.in
+
+		collected, err := collectMetrics(c, "local_router")
+		require.NoError(t, err)
+		require.Equal(t, tc.wantLogs, collected.logged)
+		require.Equal(t, tc.wantErrCounter, *collected.errors.Counter.Value)
+		requireMetricsEqual(t, tc.wantMetrics, collected.collected)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	NoCollectorDatabase      bool `arg:"--no-collector.database" help:"Disable the Database collector"`
 	NoCollectorInternet      bool `arg:"--no-collector.internet" help:"Disable the Internet(Switch+Router) collector"`
 	NoCollectorLoadBalancer  bool `arg:"--no-collector.load-balancer" help:"Disable the LoadBalancer collector"`
+	NoCollectorLocalRouter   bool `arg:"--no-collector.local-router" help:"Disable the LocalRouter collector"`
 	NoCollectorMobileGateway bool `arg:"--no-collector.mobile-gateway" help:"Disable the MobileGateway collector"`
 	NoCollectorNFS           bool `arg:"--no-collector.nfs" help:"Disable the NFS collector"`
 	NoCollectorProxyLB       bool `arg:"--no-collector.proxy-lb" help:"Disable the ProxyLB(Enhanced LoadBalancer) collector"`

--- a/examples/fake/generate-fake-store-json/example-fake-store.json
+++ b/examples/fake/generate-fake-store-json/example-fake-store.json
@@ -4550,10 +4550,10 @@
 			"wed",
 			"fri"
 		],
-		"CreatedAt": "2020-01-16T16:14:29.751501+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.280281+09:00",
 		"Description": "desc",
 		"DiskID": 100000000015,
-		"ID": "100000000022",
+		"ID": "100000000023",
 		"IconID": 0,
 		"MaximumNumberOfArchives": 5,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
@@ -4569,11 +4569,11 @@
 	},
 	{
 		"Amount": 1080,
-		"Date": "2020-01-16T16:14:23.877168+09:00",
+		"Date": "2020-01-21T19:08:08.374789+09:00",
 		"ID": "100000000001",
 		"MemberID": "dummy00000",
 		"Paid": false,
-		"PayLimit": "2020-02-16T16:14:23.877168+09:00",
+		"PayLimit": "2020-02-21T19:08:08.374789+09:00",
 		"PaymentClassID": 999,
 		"ResourceType": "Bill",
 		"ZoneName": "is1a"
@@ -4589,7 +4589,7 @@
 				"ServiceClassID": 999,
 				"Usage": 100,
 				"Zone": "tk1a",
-				"ContractEndAt": "2020-01-16T16:14:23.904466+09:00"
+				"ContractEndAt": "2020-01-21T19:08:08.412474+09:00"
 			}
 		],
 		"ZoneName": "is1a"
@@ -7187,14 +7187,14 @@
 		"ZoneName": "is1b"
 	},
 	{
-		"AppliedAt": "2019-12-16T16:14:23.959576+09:00",
+		"AppliedAt": "2019-12-21T19:08:08.458601+09:00",
 		"ContractID": 100000000004,
 		"Discount": 20000,
 		"ID": "100000000003",
 		"MemberID": "dummy00000",
 		"ResourceType": "Coupon",
 		"ServiceClassID": 999,
-		"UntilAt": "2020-02-16T16:14:23.959577+09:00",
+		"UntilAt": "2020-02-21T19:08:08.458602+09:00",
 		"ZoneName": "is1a"
 	},
 	{
@@ -7226,10 +7226,10 @@
 			"DefaultUser": "user01",
 			"UserPassword": "dummy-password-01"
 		},
-		"CreatedAt": "2020-01-16T16:14:29.683393+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.976017+09:00",
 		"DefaultRoute": "192.168.0.1",
 		"Description": "desc",
-		"ID": "100000000021",
+		"ID": "100000000019",
 		"IPAddresses": [
 			"192.168.0.11"
 		],
@@ -7237,7 +7237,7 @@
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:30.302717+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:14.473476+09:00",
 		"Interfaces": [],
 		"ModifiedAt": "0001-01-01T00:00:00Z",
 		"Name": "example",
@@ -7246,7 +7246,7 @@
 		"ReplicationSetting": null,
 		"ResourceType": "Database",
 		"SettingsHash": "",
-		"SwitchID": 100000000013,
+		"SwitchID": 100000000010,
 		"Tags": [
 			"database",
 			"example"
@@ -7259,7 +7259,7 @@
 		"BundleInfo": null,
 		"Connection": "virtio",
 		"ConnectionOrder": 0,
-		"CreatedAt": "2020-01-16T16:14:29.33603+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.792481+09:00",
 		"Description": "desc",
 		"DiskPlanID": 4,
 		"DiskPlanName": "SSDプラン",
@@ -7290,7 +7290,7 @@
 		"BundleInfo": null,
 		"Connection": "virtio",
 		"ConnectionOrder": 0,
-		"CreatedAt": "2020-01-16T16:14:31.343816+09:00",
+		"CreatedAt": "2020-01-21T19:08:15.769685+09:00",
 		"Description": "desc",
 		"DiskPlanID": 4,
 		"DiskPlanName": "SSDプラン",
@@ -7303,7 +7303,7 @@
 		"Name": "example-disk-for-server",
 		"ReinstallCount": 0,
 		"ResourceType": "Disk",
-		"ServerID": 100000000023,
+		"ServerID": 100000000018,
 		"SizeMB": 20480,
 		"SourceArchiveAvailability": "available",
 		"SourceArchiveID": 113101598580,
@@ -7336,29 +7336,7 @@
 			}
 		],
 		"StorageClass": "iscsi1204",
-		"ZoneName": "is1a"
-	},
-	{
-		"Availability": "available",
-		"ID": "2",
-		"Name": "HDDプラン",
-		"ResourceType": "DiskPlan",
-		"Size": [
-			{
-				"Availability": "available",
-				"DisplaySize": 20,
-				"DisplaySuffix": "GB",
-				"SizeMB": 20480
-			},
-			{
-				"Availability": "available",
-				"DisplaySize": 40,
-				"DisplaySuffix": "GB",
-				"SizeMB": 40960
-			}
-		],
-		"StorageClass": "iscsi1204",
-		"ZoneName": "is1b"
+		"ZoneName": "tk1a"
 	},
 	{
 		"Availability": "available",
@@ -7402,12 +7380,12 @@
 			}
 		],
 		"StorageClass": "iscsi1204",
-		"ZoneName": "tk1a"
+		"ZoneName": "is1b"
 	},
 	{
 		"Availability": "available",
-		"ID": "4",
-		"Name": "SSDプラン",
+		"ID": "2",
+		"Name": "HDDプラン",
 		"ResourceType": "DiskPlan",
 		"Size": [
 			{
@@ -7424,7 +7402,7 @@
 			}
 		],
 		"StorageClass": "iscsi1204",
-		"ZoneName": "tk1a"
+		"ZoneName": "is1a"
 	},
 	{
 		"Availability": "available",
@@ -7468,7 +7446,7 @@
 			}
 		],
 		"StorageClass": "iscsi1204",
-		"ZoneName": "tk1v"
+		"ZoneName": "is1b"
 	},
 	{
 		"Availability": "available",
@@ -7490,12 +7468,34 @@
 			}
 		],
 		"StorageClass": "iscsi1204",
-		"ZoneName": "is1b"
+		"ZoneName": "tk1a"
 	},
 	{
-		"CreatedAt": "2020-01-16T16:14:30.162956+09:00",
+		"Availability": "available",
+		"ID": "4",
+		"Name": "SSDプラン",
+		"ResourceType": "DiskPlan",
+		"Size": [
+			{
+				"Availability": "available",
+				"DisplaySize": 20,
+				"DisplaySuffix": "GB",
+				"SizeMB": 20480
+			},
+			{
+				"Availability": "available",
+				"DisplaySize": 40,
+				"DisplaySuffix": "GB",
+				"SizeMB": 40960
+			}
+		],
+		"StorageClass": "iscsi1204",
+		"ZoneName": "tk1v"
+	},
+	{
+		"CreatedAt": "2020-01-21T19:08:14.541578+09:00",
 		"HostName": "",
-		"ID": "100000000026",
+		"ID": "100000000025",
 		"IPAddress": "",
 		"MACAddress": "00:00:5e:00:53:01",
 		"PacketFilterID": 0,
@@ -7507,21 +7507,21 @@
 		"ZoneName": "is1a"
 	},
 	{
-		"CreatedAt": "2020-01-16T16:14:30.251762+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.609298+09:00",
 		"HostName": "",
-		"ID": "100000000027",
+		"ID": "100000000026",
 		"IPAddress": "",
 		"MACAddress": "00:00:5e:00:53:02",
 		"PacketFilterID": 0,
 		"ResourceType": "Interface",
-		"ServerID": 100000000023,
+		"ServerID": 100000000021,
 		"SwitchID": 100000000005,
 		"SwitchScope": "",
 		"UserIPAddress": "",
 		"ZoneName": "is1a"
 	},
 	{
-		"CreatedAt": "2020-01-16T16:14:30.623181+09:00",
+		"CreatedAt": "2020-01-21T19:08:15.194305+09:00",
 		"HostName": "",
 		"ID": "100000000030",
 		"IPAddress": "",
@@ -7529,39 +7529,39 @@
 		"PacketFilterID": 0,
 		"ResourceType": "Interface",
 		"ServerID": 0,
-		"SwitchID": 100000000017,
+		"SwitchID": 100000000027,
 		"SwitchScope": "",
 		"UserIPAddress": "",
 		"ZoneName": "is1a"
 	},
 	{
-		"CreatedAt": "2020-01-16T16:14:30.898326+09:00",
+		"CreatedAt": "2020-01-21T19:08:15.26873+09:00",
 		"HostName": "",
 		"ID": "100000000031",
 		"IPAddress": "",
 		"MACAddress": "00:00:5e:00:53:04",
 		"PacketFilterID": 0,
 		"ResourceType": "Interface",
-		"ServerID": 100000000023,
-		"SwitchID": 100000000014,
+		"ServerID": 100000000018,
+		"SwitchID": 100000000008,
 		"SwitchScope": "",
 		"UserIPAddress": "",
 		"ZoneName": "is1a"
 	},
 	{
 		"BandWidthMbps": 500,
-		"CreatedAt": "2020-01-16T16:14:28.990922+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.481503+09:00",
 		"Description": "desc",
-		"ID": "100000000008",
+		"ID": "100000000009",
 		"IconID": 0,
-		"Name": "example-router-for-vpc",
+		"Name": "example",
 		"NetworkMaskLen": 28,
 		"ResourceType": "Internet",
 		"Switch": {
 			"Description": "",
 			"ID": 100000000017,
 			"IPv6Nets": [],
-			"Name": "example-router-for-vpc",
+			"Name": "example",
 			"Scope": "user",
 			"Subnets": [
 				{
@@ -7577,24 +7577,24 @@
 		},
 		"Tags": [
 			"example",
-			"vpc-router"
+			"switch+router"
 		],
 		"ZoneName": "is1a"
 	},
 	{
 		"BandWidthMbps": 500,
-		"CreatedAt": "2020-01-16T16:14:29.07329+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.758252+09:00",
 		"Description": "desc",
-		"ID": "100000000009",
+		"ID": "100000000014",
 		"IconID": 0,
-		"Name": "example",
+		"Name": "example-router-for-vpc",
 		"NetworkMaskLen": 28,
 		"ResourceType": "Internet",
 		"Switch": {
 			"Description": "",
-			"ID": 100000000025,
+			"ID": 100000000027,
 			"IPv6Nets": [],
-			"Name": "example",
+			"Name": "example-router-for-vpc",
 			"Scope": "user",
 			"Subnets": [
 				{
@@ -7610,7 +7610,7 @@
 		},
 		"Tags": [
 			"example",
-			"switch+router"
+			"vpc-router"
 		],
 		"ZoneName": "is1a"
 	},
@@ -7620,14 +7620,6 @@
 		"ID": "100",
 		"Name": "100Mbps共有",
 		"ResourceType": "InternetPlan",
-		"ZoneName": "is1a"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 100,
-		"ID": "100",
-		"Name": "100Mbps共有",
-		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1a"
 	},
 	{
@@ -7648,17 +7640,9 @@
 	},
 	{
 		"Availability": "available",
-		"BandWidthMbps": 250,
-		"ID": "250",
-		"Name": "250Mbps共有",
-		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1a"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 250,
-		"ID": "250",
-		"Name": "250Mbps共有",
+		"BandWidthMbps": 100,
+		"ID": "100",
+		"Name": "100Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "is1a"
 	},
@@ -7675,6 +7659,38 @@
 		"BandWidthMbps": 250,
 		"ID": "250",
 		"Name": "250Mbps共有",
+		"ResourceType": "InternetPlan",
+		"ZoneName": "tk1a"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 250,
+		"ID": "250",
+		"Name": "250Mbps共有",
+		"ResourceType": "InternetPlan",
+		"ZoneName": "is1b"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 250,
+		"ID": "250",
+		"Name": "250Mbps共有",
+		"ResourceType": "InternetPlan",
+		"ZoneName": "is1a"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 500,
+		"ID": "500",
+		"Name": "500Mbps共有",
+		"ResourceType": "InternetPlan",
+		"ZoneName": "is1a"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 500,
+		"ID": "500",
+		"Name": "500Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "is1b"
 	},
@@ -7693,22 +7709,6 @@
 		"Name": "500Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1v"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 500,
-		"ID": "500",
-		"Name": "500Mbps共有",
-		"ResourceType": "InternetPlan",
-		"ZoneName": "is1b"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 500,
-		"ID": "500",
-		"Name": "500Mbps共有",
-		"ResourceType": "InternetPlan",
-		"ZoneName": "is1a"
 	},
 	{
 		"Availability": "available",
@@ -7748,7 +7748,7 @@
 		"ID": "1500",
 		"Name": "1500Mbps共有",
 		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1a"
+		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -7772,7 +7772,7 @@
 		"ID": "1500",
 		"Name": "1500Mbps共有",
 		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1v"
+		"ZoneName": "tk1a"
 	},
 	{
 		"Availability": "available",
@@ -7781,6 +7781,14 @@
 		"Name": "2000Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1a"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 2000,
+		"ID": "2000",
+		"Name": "2000Mbps共有",
+		"ResourceType": "InternetPlan",
+		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -7797,14 +7805,6 @@
 		"Name": "2000Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "is1a"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 2000,
-		"ID": "2000",
-		"Name": "2000Mbps共有",
-		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -7828,7 +7828,7 @@
 		"ID": "2500",
 		"Name": "2500Mbps共有",
 		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1a"
+		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -7836,23 +7836,7 @@
 		"ID": "2500",
 		"Name": "2500Mbps共有",
 		"ResourceType": "InternetPlan",
-		"ZoneName": "tk1v"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 3000,
-		"ID": "3000",
-		"Name": "3000Mbps共有",
-		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1a"
-	},
-	{
-		"Availability": "available",
-		"BandWidthMbps": 3000,
-		"ID": "3000",
-		"Name": "3000Mbps共有",
-		"ResourceType": "InternetPlan",
-		"ZoneName": "is1a"
 	},
 	{
 		"Availability": "available",
@@ -7868,13 +7852,21 @@
 		"ID": "3000",
 		"Name": "3000Mbps共有",
 		"ResourceType": "InternetPlan",
+		"ZoneName": "is1a"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 3000,
+		"ID": "3000",
+		"Name": "3000Mbps共有",
+		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
-		"BandWidthMbps": 5000,
-		"ID": "5000",
-		"Name": "5000Mbps共有",
+		"BandWidthMbps": 3000,
+		"ID": "3000",
+		"Name": "3000Mbps共有",
 		"ResourceType": "InternetPlan",
 		"ZoneName": "tk1a"
 	},
@@ -7892,6 +7884,14 @@
 		"ID": "5000",
 		"Name": "5000Mbps共有",
 		"ResourceType": "InternetPlan",
+		"ZoneName": "tk1v"
+	},
+	{
+		"Availability": "available",
+		"BandWidthMbps": 5000,
+		"ID": "5000",
+		"Name": "5000Mbps共有",
+		"ResourceType": "InternetPlan",
 		"ZoneName": "is1b"
 	},
 	{
@@ -7900,6 +7900,15 @@
 		"ID": "5000",
 		"Name": "5000Mbps共有",
 		"ResourceType": "InternetPlan",
+		"ZoneName": "tk1a"
+	},
+	{
+		"CreatedAt": "0001-01-01T00:00:00Z",
+		"ID": "10001",
+		"ModifiedAt": "0001-01-01T00:00:00Z",
+		"Name": "Windows RDS SAL",
+		"ResourceType": "LicenseInfo",
+		"TermsOfUse": "1ライセンスにつき、1人のユーザが利用できます。",
 		"ZoneName": "tk1v"
 	},
 	{
@@ -7909,25 +7918,16 @@
 		"Name": "Windows RDS SAL",
 		"ResourceType": "LicenseInfo",
 		"TermsOfUse": "1ライセンスにつき、1人のユーザが利用できます。",
-		"ZoneName": "is1b"
-	},
-	{
-		"CreatedAt": "0001-01-01T00:00:00Z",
-		"ID": "10001",
-		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "Windows RDS SAL",
-		"ResourceType": "LicenseInfo",
-		"TermsOfUse": "1ライセンスにつき、1人のユーザが利用できます。",
-		"ZoneName": "tk1v"
-	},
-	{
-		"CreatedAt": "0001-01-01T00:00:00Z",
-		"ID": "10001",
-		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "Windows RDS SAL",
-		"ResourceType": "LicenseInfo",
-		"TermsOfUse": "1ライセンスにつき、1人のユーザが利用できます。",
 		"ZoneName": "tk1a"
+	},
+	{
+		"CreatedAt": "0001-01-01T00:00:00Z",
+		"ID": "10001",
+		"ModifiedAt": "0001-01-01T00:00:00Z",
+		"Name": "Windows RDS SAL",
+		"ResourceType": "LicenseInfo",
+		"TermsOfUse": "1ライセンスにつき、1人のユーザが利用できます。",
+		"ZoneName": "is1b"
 	},
 	{
 		"CreatedAt": "0001-01-01T00:00:00Z",
@@ -7941,10 +7941,10 @@
 	{
 		"Availability": "available",
 		"Class": "loadbalancer",
-		"CreatedAt": "2020-01-16T16:14:29.563605+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.145995+09:00",
 		"DefaultRoute": "192.168.0.1",
 		"Description": "desc",
-		"ID": "100000000019",
+		"ID": "100000000022",
 		"IPAddresses": [
 			"192.168.0.11",
 			"192.168.0.12"
@@ -7953,7 +7953,7 @@
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:30.111469+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:14.729713+09:00",
 		"Interfaces": [],
 		"ModifiedAt": "0001-01-01T00:00:00Z",
 		"Name": "example",
@@ -7961,7 +7961,7 @@
 		"PlanID": 1,
 		"ResourceType": "LoadBalancer",
 		"SettingsHash": "",
-		"SwitchID": 100000000011,
+		"SwitchID": 100000000013,
 		"Tags": [
 			"example",
 			"load-balancer",
@@ -8005,21 +8005,21 @@
 	{
 		"Availability": "available",
 		"Class": "mobilegateway",
-		"CreatedAt": "2020-01-16T16:14:29.513787+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.097119+09:00",
 		"Description": "desc",
-		"ID": "100000000018",
+		"ID": "100000000021",
 		"IconID": 0,
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:36.004189+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:20.395188+09:00",
 		"Interfaces": [
 			{
 				"HostName": "",
 				"ID": 100000000026,
 				"IPAddress": "",
 				"Index": 0,
-				"MACAddress": "00:00:5e:00:53:01",
+				"MACAddress": "00:00:5e:00:53:02",
 				"PacketFilterID": 0,
 				"PacketFilterName": "",
 				"PacketFilterRequiredHostVersion": 0,
@@ -8055,12 +8055,12 @@
 	{
 		"DNS1": "133.242.0.1",
 		"DNS2": "133.242.0.2",
-		"ID": "100000000018",
+		"ID": "100000000021",
 		"ResourceType": "MobileGatewayDNS",
 		"ZoneName": "is1a"
 	},
 	{
-		"ID": "100000000018",
+		"ID": "100000000021",
 		"ResourceType": "MobileGatewaySIMs",
 		"Values": [
 			{
@@ -8071,8 +8071,8 @@
 				"IMEILock": false,
 				"Registered": true,
 				"Activated": false,
-				"ResourceID": "100000000010",
-				"RegisteredDate": "2020-01-16T16:14:29.089918+09:00",
+				"ResourceID": "100000000012",
+				"RegisteredDate": "2020-01-21T19:08:13.658656+09:00",
 				"ActivatedDate": "0001-01-01T00:00:00Z",
 				"DeactivatedDate": "0001-01-01T00:00:00Z",
 				"SIMGroupID": "",
@@ -8086,7 +8086,7 @@
 		"AutoTrafficShaping": true,
 		"BandWidthLimitInKbps": 64,
 		"EmailNotifyEnabled": true,
-		"ID": "100000000018",
+		"ID": "100000000021",
 		"ResourceType": "MobileGatewayTrafficConfig",
 		"SlackNotifyEnabled": true,
 		"SlackNotifyWebhooksURL": "https://xxxxxx.slack.com/example-webhook-url",
@@ -8096,7 +8096,7 @@
 	{
 		"Availability": "available",
 		"Class": "nfs",
-		"CreatedAt": "2020-01-16T16:14:29.612639+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.024365+09:00",
 		"DefaultRoute": "192.168.0.1",
 		"Description": "desc",
 		"ID": "100000000020",
@@ -8107,14 +8107,14 @@
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:30.216096+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:14.592838+09:00",
 		"Interfaces": [],
 		"ModifiedAt": "0001-01-01T00:00:00Z",
 		"Name": "example",
 		"NetworkMaskLen": 24,
 		"PlanID": 101,
 		"ResourceType": "NFS",
-		"SwitchID": 100000000012,
+		"SwitchID": 100000000011,
 		"SwitchName": "",
 		"Tags": [
 			"example",
@@ -8146,16 +8146,6 @@
 		"MemoryMB": 229376,
 		"Name": "200Core 224GB 標準",
 		"ResourceType": "PrivateHostPlan",
-		"ZoneName": "is1b"
-	},
-	{
-		"Availability": "available",
-		"CPU": 200,
-		"Class": "dynamic",
-		"ID": "112900526366",
-		"MemoryMB": 229376,
-		"Name": "200Core 224GB 標準",
-		"ResourceType": "PrivateHostPlan",
 		"ZoneName": "tk1a"
 	},
 	{
@@ -8176,27 +8166,17 @@
 		"MemoryMB": 229376,
 		"Name": "200Core 224GB 標準",
 		"ResourceType": "PrivateHostPlan",
-		"ZoneName": "tk1v"
-	},
-	{
-		"Availability": "available",
-		"CPU": 200,
-		"Class": "ms_windows",
-		"ID": "113102196877",
-		"MemoryMB": 229376,
-		"Name": "200Core 224GB Windows",
-		"ResourceType": "PrivateHostPlan",
-		"ZoneName": "is1a"
-	},
-	{
-		"Availability": "available",
-		"CPU": 200,
-		"Class": "ms_windows",
-		"ID": "113102196877",
-		"MemoryMB": 229376,
-		"Name": "200Core 224GB Windows",
-		"ResourceType": "PrivateHostPlan",
 		"ZoneName": "is1b"
+	},
+	{
+		"Availability": "available",
+		"CPU": 200,
+		"Class": "dynamic",
+		"ID": "112900526366",
+		"MemoryMB": 229376,
+		"Name": "200Core 224GB 標準",
+		"ResourceType": "PrivateHostPlan",
+		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -8216,7 +8196,27 @@
 		"MemoryMB": 229376,
 		"Name": "200Core 224GB Windows",
 		"ResourceType": "PrivateHostPlan",
+		"ZoneName": "is1a"
+	},
+	{
+		"Availability": "available",
+		"CPU": 200,
+		"Class": "ms_windows",
+		"ID": "113102196877",
+		"MemoryMB": 229376,
+		"Name": "200Core 224GB Windows",
+		"ResourceType": "PrivateHostPlan",
 		"ZoneName": "tk1v"
+	},
+	{
+		"Availability": "available",
+		"CPU": 200,
+		"Class": "ms_windows",
+		"ID": "113102196877",
+		"MemoryMB": 229376,
+		"Name": "200Core 224GB Windows",
+		"ResourceType": "PrivateHostPlan",
+		"ZoneName": "is1b"
 	},
 	{
 		"Availability": "available",
@@ -8236,7 +8236,7 @@
 				"SupportHTTP2": true
 			}
 		],
-		"CreatedAt": "2020-01-16T16:14:29.384089+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.842398+09:00",
 		"Description": "desc",
 		"FQDN": "fake.proxylb.sakura.ne.jp",
 		"HealthCheck": {
@@ -8354,10 +8354,10 @@
 	{
 		"Availability": "available",
 		"Class": "sim",
-		"CreatedAt": "2020-01-16T16:14:29.089916+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.658654+09:00",
 		"Description": "desc",
 		"ICCID": "123456789012345",
-		"ID": "100000000010",
+		"ID": "100000000012",
 		"IconID": 0,
 		"Info": {
 			"Activated": false,
@@ -8369,13 +8369,13 @@
 			"IMSI": null,
 			"IP": "10.0.0.123",
 			"Registered": true,
-			"RegisteredDate": "2020-01-16T16:14:29.089918+09:00",
-			"ResourceID": "100000000010",
+			"RegisteredDate": "2020-01-21T19:08:13.658656+09:00",
+			"ResourceID": "100000000012",
 			"SIMGroupID": "",
 			"SessionStatus": "",
 			"TrafficBytesOfCurrentMonth": null
 		},
-		"ModifiedAt": "2020-01-16T16:14:29.089917+09:00",
+		"ModifiedAt": "2020-01-21T19:08:13.658656+09:00",
 		"Name": "example",
 		"ResourceType": "SIM",
 		"Tags": [
@@ -8389,7 +8389,7 @@
 		"BundleInfo": null,
 		"CDROMID": 0,
 		"CPU": 2,
-		"CreatedAt": "2020-01-16T16:14:29.920838+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.905801+09:00",
 		"Description": "desc",
 		"Disks": [
 			{
@@ -8405,22 +8405,22 @@
 			}
 		],
 		"HostName": "",
-		"ID": "100000000023",
+		"ID": "100000000018",
 		"IconID": 0,
 		"InstanceBeforeStatus": "",
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:36.515679+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:20.952905+09:00",
 		"InstanceWarnings": "",
 		"InstanceWarningsValue": 0,
 		"InterfaceDriver": "virtio",
 		"Interfaces": [
 			{
 				"HostName": "",
-				"ID": 100000000027,
+				"ID": 100000000025,
 				"IPAddress": "",
-				"MACAddress": "00:00:5e:00:53:02",
+				"MACAddress": "00:00:5e:00:53:01",
 				"PacketFilterID": 0,
 				"PacketFilterName": "",
 				"PacketFilterRequiredHostVersion": 0,
@@ -8448,7 +8448,7 @@
 				"SubnetDefaultRoute": "",
 				"SubnetNetworkAddress": "",
 				"SubnetNetworkMaskLen": 0,
-				"SwitchID": 100000000014,
+				"SwitchID": 100000000008,
 				"SwitchName": "",
 				"SwitchScope": "user",
 				"UpstreamType": "",
@@ -8510,6 +8510,17 @@
 		"MemoryMB": 1,
 		"Name": "プラン/1Core-1GB",
 		"ResourceType": "ServerPlan",
+		"ZoneName": "is1b"
+	},
+	{
+		"Availability": "available",
+		"CPU": 1,
+		"Commitment": "standard",
+		"Generation": 100,
+		"ID": "100000000006",
+		"MemoryMB": 1,
+		"Name": "プラン/1Core-1GB",
+		"ResourceType": "ServerPlan",
 		"ZoneName": "tk1v"
 	},
 	{
@@ -8522,39 +8533,6 @@
 		"Name": "プラン/1Core-1GB",
 		"ResourceType": "ServerPlan",
 		"ZoneName": "is1a"
-	},
-	{
-		"Availability": "available",
-		"CPU": 1,
-		"Commitment": "standard",
-		"Generation": 100,
-		"ID": "100000000006",
-		"MemoryMB": 1,
-		"Name": "プラン/1Core-1GB",
-		"ResourceType": "ServerPlan",
-		"ZoneName": "is1b"
-	},
-	{
-		"Availability": "available",
-		"CPU": 2,
-		"Commitment": "standard",
-		"Generation": 100,
-		"ID": "100000000007",
-		"MemoryMB": 4,
-		"Name": "プラン/2Core-4GB",
-		"ResourceType": "ServerPlan",
-		"ZoneName": "is1b"
-	},
-	{
-		"Availability": "available",
-		"CPU": 2,
-		"Commitment": "standard",
-		"Generation": 100,
-		"ID": "100000000007",
-		"MemoryMB": 4,
-		"Name": "プラン/2Core-4GB",
-		"ResourceType": "ServerPlan",
-		"ZoneName": "tk1v"
 	},
 	{
 		"Availability": "available",
@@ -8576,39 +8554,29 @@
 		"MemoryMB": 4,
 		"Name": "プラン/2Core-4GB",
 		"ResourceType": "ServerPlan",
-		"ZoneName": "is1a"
+		"ZoneName": "is1b"
 	},
 	{
-		"DisplayName": "プラン1(ディスクなし)",
-		"ID": "50050",
-		"IsPublic": true,
-		"Price": {
-			"Base": 0,
-			"Daily": 108,
-			"Hourly": 10,
-			"Monthly": 2139,
-			"Zone": "is1a"
-		},
-		"ResourceType": "ServiceClass",
-		"ServiceClassName": "plan/1",
-		"ServiceClassPath": "cloud/plan/1",
-		"ZoneName": "is1a"
+		"Availability": "available",
+		"CPU": 2,
+		"Commitment": "standard",
+		"Generation": 100,
+		"ID": "100000000007",
+		"MemoryMB": 4,
+		"Name": "プラン/2Core-4GB",
+		"ResourceType": "ServerPlan",
+		"ZoneName": "tk1v"
 	},
 	{
-		"DisplayName": "プラン1(ディスクなし)",
-		"ID": "50050",
-		"IsPublic": true,
-		"Price": {
-			"Base": 0,
-			"Daily": 108,
-			"Hourly": 10,
-			"Monthly": 2139,
-			"Zone": "tk1a"
-		},
-		"ResourceType": "ServiceClass",
-		"ServiceClassName": "plan/1",
-		"ServiceClassPath": "cloud/plan/1",
-		"ZoneName": "tk1a"
+		"Availability": "available",
+		"CPU": 2,
+		"Commitment": "standard",
+		"Generation": 100,
+		"ID": "100000000007",
+		"MemoryMB": 4,
+		"Name": "プラン/2Core-4GB",
+		"ResourceType": "ServerPlan",
+		"ZoneName": "is1a"
 	},
 	{
 		"DisplayName": "プラン1(ディスクなし)",
@@ -8635,28 +8603,44 @@
 			"Daily": 108,
 			"Hourly": 10,
 			"Monthly": 2139,
+			"Zone": "tk1a"
+		},
+		"ResourceType": "ServiceClass",
+		"ServiceClassName": "plan/1",
+		"ServiceClassPath": "cloud/plan/1",
+		"ZoneName": "tk1a"
+	},
+	{
+		"DisplayName": "プラン1(ディスクなし)",
+		"ID": "50050",
+		"IsPublic": true,
+		"Price": {
+			"Base": 0,
+			"Daily": 108,
+			"Hourly": 10,
+			"Monthly": 2139,
+			"Zone": "is1a"
+		},
+		"ResourceType": "ServiceClass",
+		"ServiceClassName": "plan/1",
+		"ServiceClassPath": "cloud/plan/1",
+		"ZoneName": "is1a"
+	},
+	{
+		"DisplayName": "プラン1(ディスクなし)",
+		"ID": "50050",
+		"IsPublic": true,
+		"Price": {
+			"Base": 0,
+			"Daily": 108,
+			"Hourly": 10,
+			"Monthly": 2139,
 			"Zone": "is1b"
 		},
 		"ResourceType": "ServiceClass",
 		"ServiceClassName": "plan/1",
 		"ServiceClassPath": "cloud/plan/1",
 		"ZoneName": "is1b"
-	},
-	{
-		"DisplayName": "プラン2(ディスクなし)",
-		"ID": "50051",
-		"IsPublic": true,
-		"Price": {
-			"Base": 0,
-			"Daily": 172,
-			"Hourly": 17,
-			"Monthly": 3425,
-			"Zone": "tk1a"
-		},
-		"ResourceType": "ServiceClass",
-		"ServiceClassName": "plan/2",
-		"ServiceClassPath": "cloud/plan/2",
-		"ZoneName": "tk1a"
 	},
 	{
 		"DisplayName": "プラン2(ディスクなし)",
@@ -8705,6 +8689,22 @@
 		"ServiceClassName": "plan/2",
 		"ServiceClassPath": "cloud/plan/2",
 		"ZoneName": "is1a"
+	},
+	{
+		"DisplayName": "プラン2(ディスクなし)",
+		"ID": "50051",
+		"IsPublic": true,
+		"Price": {
+			"Base": 0,
+			"Daily": 172,
+			"Hourly": 17,
+			"Monthly": 3425,
+			"Zone": "tk1a"
+		},
+		"ResourceType": "ServiceClass",
+		"ServiceClassName": "plan/2",
+		"ServiceClassPath": "cloud/plan/2",
+		"ZoneName": "tk1a"
 	},
 	{
 		"DefaultRoute": "28.0.0.17",
@@ -8755,7 +8755,7 @@
 				"IPAddress": "28.0.0.30"
 			}
 		],
-		"InternetID": 100000000008,
+		"InternetID": 100000000009,
 		"NetworkAddress": "28.0.0.16",
 		"NetworkMaskLen": 28,
 		"NextHop": "",
@@ -8813,13 +8813,13 @@
 				"IPAddress": "28.0.0.46"
 			}
 		],
-		"InternetID": 100000000009,
+		"InternetID": 100000000014,
 		"NetworkAddress": "28.0.0.32",
 		"NetworkMaskLen": 28,
 		"NextHop": "",
 		"ResourceType": "Subnet",
 		"StaticRoute": "",
-		"SwitchID": 100000000025,
+		"SwitchID": 100000000027,
 		"ZoneName": "is1a"
 	},
 	{
@@ -8827,6 +8827,7 @@
 		"CreatedAt": "0001-01-01T00:00:00Z",
 		"DefaultRoute": "192.0.2.1",
 		"Description": "共有セグメント用スイッチ",
+		"HybridConnectionID": 0,
 		"ID": "100000000005",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
@@ -8856,6 +8857,7 @@
 		"CreatedAt": "0001-01-01T00:00:00Z",
 		"DefaultRoute": "192.0.2.1",
 		"Description": "共有セグメント用スイッチ",
+		"HybridConnectionID": 0,
 		"ID": "100000000005",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
@@ -8885,6 +8887,7 @@
 		"CreatedAt": "0001-01-01T00:00:00Z",
 		"DefaultRoute": "192.0.2.1",
 		"Description": "共有セグメント用スイッチ",
+		"HybridConnectionID": 0,
 		"ID": "100000000005",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
@@ -8914,6 +8917,7 @@
 		"CreatedAt": "0001-01-01T00:00:00Z",
 		"DefaultRoute": "192.0.2.1",
 		"Description": "共有セグメント用スイッチ",
+		"HybridConnectionID": 0,
 		"ID": "100000000005",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
@@ -8940,10 +8944,74 @@
 	},
 	{
 		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:29.137262+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.433692+09:00",
+		"DefaultRoute": "",
+		"Description": "desc",
+		"HybridConnectionID": 0,
+		"ID": "100000000008",
+		"IconID": 0,
+		"ModifiedAt": "0001-01-01T00:00:00Z",
+		"Name": "example-for-server",
+		"NetworkMaskLen": 0,
+		"ResourceType": "Switch",
+		"Scope": "user",
+		"ServerCount": 1,
+		"Subnets": [],
+		"Tags": [
+			"example",
+			"server"
+		],
+		"ZoneName": "is1a"
+	},
+	{
+		"BridgeID": 0,
+		"CreatedAt": "2020-01-21T19:08:13.563037+09:00",
+		"DefaultRoute": "",
+		"Description": "desc",
+		"HybridConnectionID": 0,
+		"ID": "100000000010",
+		"IconID": 0,
+		"ModifiedAt": "0001-01-01T00:00:00Z",
+		"Name": "example-switch-for-database",
+		"NetworkMaskLen": 0,
+		"ResourceType": "Switch",
+		"Scope": "user",
+		"ServerCount": 0,
+		"Subnets": [],
+		"Tags": [
+			"database",
+			"example"
+		],
+		"ZoneName": "is1a"
+	},
+	{
+		"BridgeID": 0,
+		"CreatedAt": "2020-01-21T19:08:13.611981+09:00",
+		"DefaultRoute": "",
+		"Description": "desc",
+		"HybridConnectionID": 0,
+		"ID": "100000000011",
+		"IconID": 0,
+		"ModifiedAt": "0001-01-01T00:00:00Z",
+		"Name": "example-for-nfs",
+		"NetworkMaskLen": 0,
+		"ResourceType": "Switch",
+		"Scope": "user",
+		"ServerCount": 0,
+		"Subnets": [],
+		"Tags": [
+			"example",
+			"nfs"
+		],
+		"ZoneName": "is1a"
+	},
+	{
+		"BridgeID": 0,
+		"CreatedAt": "2020-01-21T19:08:13.707118+09:00",
 		"DefaultRoute": "",
 		"Description": "dest",
-		"ID": "100000000011",
+		"HybridConnectionID": 0,
+		"ID": "100000000013",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
 		"Name": "example-switch-for-load-balancer-standard",
@@ -8961,77 +9029,18 @@
 	},
 	{
 		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:29.185497+09:00",
-		"DefaultRoute": "",
-		"Description": "desc",
-		"ID": "100000000012",
-		"IconID": 0,
-		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "example-for-nfs",
-		"NetworkMaskLen": 0,
-		"ResourceType": "Switch",
-		"Scope": "user",
-		"ServerCount": 0,
-		"Subnets": [],
-		"Tags": [
-			"example",
-			"nfs"
-		],
-		"ZoneName": "is1a"
-	},
-	{
-		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:29.236054+09:00",
-		"DefaultRoute": "",
-		"Description": "desc",
-		"ID": "100000000013",
-		"IconID": 0,
-		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "example-switch-for-database",
-		"NetworkMaskLen": 0,
-		"ResourceType": "Switch",
-		"Scope": "user",
-		"ServerCount": 0,
-		"Subnets": [],
-		"Tags": [
-			"database",
-			"example"
-		],
-		"ZoneName": "is1a"
-	},
-	{
-		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:29.286682+09:00",
-		"DefaultRoute": "",
-		"Description": "desc",
-		"ID": "100000000014",
-		"IconID": 0,
-		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "example-for-server",
-		"NetworkMaskLen": 0,
-		"ResourceType": "Switch",
-		"Scope": "user",
-		"ServerCount": 1,
-		"Subnets": [],
-		"Tags": [
-			"example",
-			"server"
-		],
-		"ZoneName": "is1a"
-	},
-	{
-		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:29.41689+09:00",
+		"CreatedAt": "2020-01-21T19:08:13.858566+09:00",
 		"DefaultRoute": "28.0.0.17",
 		"Description": "",
+		"HybridConnectionID": 0,
 		"ID": "100000000017",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "example-router-for-vpc",
+		"Name": "example",
 		"NetworkMaskLen": 28,
 		"ResourceType": "Switch",
 		"Scope": "user",
-		"ServerCount": 1,
+		"ServerCount": 0,
 		"Subnets": [
 			{
 				"AssignedIPAddressMax": "28.0.0.30",
@@ -9040,17 +9049,17 @@
 				"ID": 100000000024,
 				"Internet": {
 					"BandWidthMbps": 500,
-					"CreatedAt": "2020-01-16T16:14:28.990922+09:00",
+					"CreatedAt": "2020-01-21T19:08:13.481503+09:00",
 					"Description": "desc",
-					"ID": 100000000008,
+					"ID": 100000000009,
 					"IconID": 0,
-					"Name": "example-router-for-vpc",
+					"Name": "example",
 					"NetworkMaskLen": 28,
 					"Switch": {
 						"Description": "",
 						"ID": 100000000017,
 						"IPv6Nets": [],
-						"Name": "example-router-for-vpc",
+						"Name": "example",
 						"Scope": "user",
 						"Subnets": [
 							{
@@ -9066,7 +9075,7 @@
 					},
 					"Tags": [
 						"example",
-						"vpc-router"
+						"switch+router"
 					]
 				},
 				"NetworkAddress": "28.0.0.16",
@@ -9080,17 +9089,18 @@
 	},
 	{
 		"BridgeID": 0,
-		"CreatedAt": "2020-01-16T16:14:30.076862+09:00",
+		"CreatedAt": "2020-01-21T19:08:14.695695+09:00",
 		"DefaultRoute": "28.0.0.33",
 		"Description": "",
-		"ID": "100000000025",
+		"HybridConnectionID": 0,
+		"ID": "100000000027",
 		"IconID": 0,
 		"ModifiedAt": "0001-01-01T00:00:00Z",
-		"Name": "example",
+		"Name": "example-router-for-vpc",
 		"NetworkMaskLen": 28,
 		"ResourceType": "Switch",
 		"Scope": "user",
-		"ServerCount": 0,
+		"ServerCount": 1,
 		"Subnets": [
 			{
 				"AssignedIPAddressMax": "28.0.0.46",
@@ -9099,17 +9109,17 @@
 				"ID": 100000000028,
 				"Internet": {
 					"BandWidthMbps": 500,
-					"CreatedAt": "2020-01-16T16:14:29.07329+09:00",
+					"CreatedAt": "2020-01-21T19:08:13.758252+09:00",
 					"Description": "desc",
-					"ID": 100000000009,
+					"ID": 100000000014,
 					"IconID": 0,
-					"Name": "example",
+					"Name": "example-router-for-vpc",
 					"NetworkMaskLen": 28,
 					"Switch": {
 						"Description": "",
-						"ID": 100000000025,
+						"ID": 100000000027,
 						"IPv6Nets": [],
-						"Name": "example",
+						"Name": "example-router-for-vpc",
 						"Scope": "user",
 						"Subnets": [
 							{
@@ -9125,7 +9135,7 @@
 					},
 					"Tags": [
 						"example",
-						"switch+router"
+						"vpc-router"
 					]
 				},
 				"NetworkAddress": "28.0.0.32",
@@ -9140,14 +9150,14 @@
 	{
 		"Availability": "available",
 		"Class": "vpcrouter",
-		"CreatedAt": "2020-01-16T16:14:30.496578+09:00",
+		"CreatedAt": "2020-01-21T19:08:15.124673+09:00",
 		"Description": "desc",
 		"ID": "100000000029",
 		"IconID": 0,
 		"InstanceHostInfoURL": "",
 		"InstanceHostName": "sac-is1a-svXXX",
 		"InstanceStatus": "up",
-		"InstanceStatusChangedAt": "2020-01-16T16:14:36.14995+09:00",
+		"InstanceStatusChangedAt": "2020-01-21T19:08:20.58197+09:00",
 		"Interfaces": [
 			{
 				"HostName": "",
@@ -9162,7 +9172,7 @@
 				"SubnetDefaultRoute": "",
 				"SubnetNetworkAddress": "",
 				"SubnetNetworkMaskLen": 0,
-				"SwitchID": 100000000017,
+				"SwitchID": 100000000027,
 				"SwitchName": "",
 				"SwitchScope": "",
 				"UpstreamType": "",
@@ -9181,13 +9191,13 @@
 			"Interfaces": [
 				{
 					"IPAddress": [
-						"28.0.0.21",
-						"28.0.0.22"
+						"28.0.0.37",
+						"28.0.0.38"
 					],
 					"IPAliases": null,
 					"Index": 0,
 					"NetworkMaskLen": 28,
-					"VirtualIPAddress": "28.0.0.20"
+					"VirtualIPAddress": "28.0.0.36"
 				}
 			],
 			"InternetConnectionEnabled": true,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
-	github.com/sacloud/libsacloud/v2 v2.0.0-rc4
+	github.com/sacloud/libsacloud/v2 v2.0.0-rc5.0.20200122082620-7e22416a425b
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jO
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc4 h1:oEvRVgfUS333jbhYZP+RTtJBHEcC3iQjnn89DgS7abs=
-github.com/sacloud/libsacloud/v2 v2.0.0-rc4/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc5.0.20200122082620-7e22416a425b h1:MTwjWigtVYUHtGvASRXaoA8UDCO63Y+25FoWA1/PVnM=
+github.com/sacloud/libsacloud/v2 v2.0.0-rc5.0.20200122082620-7e22416a425b/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=

--- a/iaas/client.go
+++ b/iaas/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	Database      DatabaseClient
 	Internet      InternetClient
 	LoadBalancer  LoadBalancerClient
+	LocalRouter   LocalRouterClient
 	MobileGateway MobileGatewayClient
 	NFS           NFSClient
 	ProxyLB       ProxyLBClient
@@ -85,6 +86,7 @@ func NewSakuraCloucClient(c config.Config, version string) *Client {
 		Database:      getDatabaseClient(caller, c.Zones),
 		Internet:      getInternetClient(caller, c.Zones),
 		LoadBalancer:  getLoadBalancerClient(caller, c.Zones),
+		LocalRouter:   getLocalRouterClient(caller),
 		MobileGateway: getMobileGatewayClient(caller, c.Zones),
 		NFS:           getNFSClient(caller, c.Zones),
 		ProxyLB:       getProxyLBClient(caller),

--- a/iaas/local_router.go
+++ b/iaas/local_router.go
@@ -1,0 +1,65 @@
+// Copyright 2019-2020 The sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iaas
+
+import (
+	"context"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type LocalRouterClient interface {
+	Find(ctx context.Context) ([]*sacloud.LocalRouter, error)
+	Health(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error)
+	Monitor(ctx context.Context, id types.ID, end time.Time) (*sacloud.MonitorLocalRouterValue, error)
+}
+
+func getLocalRouterClient(caller sacloud.APICaller) LocalRouterClient {
+	return &localRouterClient{
+		client: sacloud.NewLocalRouterOp(caller),
+	}
+}
+
+type localRouterClient struct {
+	client sacloud.LocalRouterAPI
+}
+
+func (c *localRouterClient) Find(ctx context.Context) ([]*sacloud.LocalRouter, error) {
+	var results []*sacloud.LocalRouter
+	res, err := c.client.Find(ctx, &sacloud.FindCondition{
+		Count: 10000,
+	})
+	if err != nil {
+		return results, err
+	}
+	for _, lb := range res.LocalRouters {
+		results = append(results, lb)
+	}
+	return results, err
+}
+
+func (c *localRouterClient) Health(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	return c.client.HealthStatus(ctx, id)
+}
+
+func (c *localRouterClient) Monitor(ctx context.Context, id types.ID, end time.Time) (*sacloud.MonitorLocalRouterValue, error) {
+	mvs, err := c.client.MonitorLocalRouter(ctx, id, monitorCondition(end))
+	if err != nil {
+		return nil, err
+	}
+	return monitorLocalRouterValue(mvs.Values), nil
+}

--- a/iaas/monitor.go
+++ b/iaas/monitor.go
@@ -101,3 +101,12 @@ func monitorLinkValue(values []*sacloud.MonitorLinkValue) *sacloud.MonitorLinkVa
 	}
 	return nil
 }
+
+func monitorLocalRouterValue(values []*sacloud.MonitorLocalRouterValue) *sacloud.MonitorLocalRouterValue {
+	if len(values) > 1 {
+		// Descending
+		sort.Slice(values, func(i, j int) bool { return values[i].Time.After(values[j].Time) })
+		return values[1]
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -109,6 +109,9 @@ func main() {
 	if !c.NoCollectorLoadBalancer {
 		r.MustRegister(collector.NewLoadBalancerCollector(ctx, logger, errors, client.LoadBalancer))
 	}
+	if !c.NoCollectorLoadBalancer {
+		r.MustRegister(collector.NewLocalRouterCollector(ctx, logger, errors, client.LocalRouter))
+	}
 	if !c.NoCollectorNFS {
 		r.MustRegister(collector.NewNFSCollector(ctx, logger, errors, client.NFS))
 	}

--- a/vendor/github.com/sacloud/libsacloud/v2/pkg/mapconv/mapconv.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/pkg/mapconv/mapconv.go
@@ -131,7 +131,7 @@ func ConvertFrom(source interface{}, dest interface{}) error {
 			if err != nil {
 				return err
 			}
-			if value == nil {
+			if value == nil || reflect.ValueOf(value).IsZero() {
 				continue
 			}
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
@@ -154,6 +154,16 @@ func (s sIMFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmp)
 }
 
+func (s localRouterFindRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias localRouterFindRequestEnvelope
+	tmp := alias(s)
+	if tmp.Filter == nil {
+		tmp.Filter = search.Filter{}
+	}
+	tmp.Filter[search.Key("Provider.Class")] = "localrouter"
+	return json.Marshal(tmp)
+}
+
 func (s databaseFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	type alias databaseFindRequestEnvelope
 	tmp := alias(s)

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_local_router.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_local_router.go
@@ -1,0 +1,211 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Find is fake implementation
+func (o *LocalRouterOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LocalRouterFindResult, error) {
+	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
+	var values []*sacloud.LocalRouter
+	for _, res := range results {
+		dest := &sacloud.LocalRouter{}
+		copySameNameField(res, dest)
+		values = append(values, dest)
+	}
+	return &sacloud.LocalRouterFindResult{
+		Total:        len(results),
+		Count:        len(results),
+		From:         0,
+		LocalRouters: values,
+	}, nil
+}
+
+// Create is fake implementation
+func (o *LocalRouterOp) Create(ctx context.Context, param *sacloud.LocalRouterCreateRequest) (*sacloud.LocalRouter, error) {
+	result := &sacloud.LocalRouter{}
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt)
+
+	result.Availability = types.Availabilities.Available
+	result.SecretKeys = []string{"dummy"}
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, result.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, result)
+	return result, nil
+}
+
+// Read is fake implementation
+func (o *LocalRouterOp) Read(ctx context.Context, id types.ID) (*sacloud.LocalRouter, error) {
+	value := getLocalRouterByID(sacloud.APIDefaultZone, id)
+	if value == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	dest := &sacloud.LocalRouter{}
+	copySameNameField(value, dest)
+	return dest, nil
+}
+
+// Update is fake implementation
+func (o *LocalRouterOp) Update(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateRequest) (*sacloud.LocalRouter, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	for _, peer := range value.Peers {
+		p, err := o.Read(ctx, peer.ID)
+		if err != nil {
+			return nil, err
+		}
+		var routes []string
+		if p.Interface != nil {
+			_, ipNet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", p.Interface.VirtualIPAddress, p.Interface.NetworkMaskLen))
+			if err != nil {
+				return nil, err
+			}
+			if ipNet != nil {
+				routes = append(routes, ipNet.String())
+			}
+
+			for _, sr := range p.StaticRoutes {
+				routes = append(routes, sr.Prefix)
+			}
+		}
+
+		status.Peers = append(status.Peers, &sacloud.LocalRouterHealthPeer{
+			ID:     peer.ID,
+			Status: types.ServerInstanceStatuses.Up,
+			Routes: routes,
+		})
+	}
+
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, value.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// UpdateSettings is fake implementation
+func (o *LocalRouterOp) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateSettingsRequest) (*sacloud.LocalRouter, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	for _, peer := range value.Peers {
+		p, err := o.Read(ctx, peer.ID)
+		if err != nil {
+			return nil, err
+		}
+		var routes []string
+		if p.Interface != nil {
+			_, ipNet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", p.Interface.VirtualIPAddress, p.Interface.NetworkMaskLen))
+			if err != nil {
+				return nil, err
+			}
+			if ipNet != nil {
+				routes = append(routes, ipNet.String())
+			}
+
+			for _, sr := range p.StaticRoutes {
+				routes = append(routes, sr.Prefix)
+			}
+		}
+
+		status.Peers = append(status.Peers, &sacloud.LocalRouterHealthPeer{
+			ID:     peer.ID,
+			Status: types.ServerInstanceStatuses.Up,
+			Routes: routes,
+		})
+	}
+
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, value.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Delete is fake implementation
+func (o *LocalRouterOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	ds().Delete(o.key, sacloud.APIDefaultZone, id)
+	return nil
+}
+
+// HealthStatus is fake implementation
+func (o *LocalRouterOp) HealthStatus(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	result := ds().Get(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, id)
+	if result == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	return result.(*sacloud.LocalRouterHealth), nil
+}
+
+// MonitorLocalRouter is fake implementation
+func (o *LocalRouterOp) MonitorLocalRouter(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LocalRouterActivity, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.LocalRouterActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorLocalRouterValue{
+			Time:               now.Add(time.Duration(i*-5) * time.Minute),
+			ReceiveBytesPerSec: float64(random(1000)),
+			SendBytesPerSec:    float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_api_ops.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_api_ops.go
@@ -91,6 +91,9 @@ func SwitchFactoryFuncToFake() {
 	sacloud.SetClientFactoryFunc(ResourceLoadBalancer, func(caller sacloud.APICaller) interface{} {
 		return NewLoadBalancerOp()
 	})
+	sacloud.SetClientFactoryFunc(ResourceLocalRouter, func(caller sacloud.APICaller) interface{} {
+		return NewLocalRouterOp()
+	})
 	sacloud.SetClientFactoryFunc(ResourceMobileGateway, func(caller sacloud.APICaller) interface{} {
 		return NewMobileGatewayOp()
 	})
@@ -515,6 +518,22 @@ type LoadBalancerOp struct {
 func NewLoadBalancerOp() sacloud.LoadBalancerAPI {
 	return &LoadBalancerOp{
 		key: ResourceLoadBalancer,
+	}
+}
+
+/*************************************************
+* LocalRouterOp
+*************************************************/
+
+// LocalRouterOp is fake implementation of LocalRouterAPI interface
+type LocalRouterOp struct {
+	key string
+}
+
+// NewLocalRouterOp creates new LocalRouterOp instance
+func NewLocalRouterOp() sacloud.LocalRouterAPI {
+	return &LocalRouterOp{
+		key: ResourceLocalRouter,
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_resources.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_resources.go
@@ -63,6 +63,8 @@ const (
 	ResourceLicenseInfo = "LicenseInfo"
 	// ResourceLoadBalancer is resource key of fake store
 	ResourceLoadBalancer = "LoadBalancer"
+	// ResourceLocalRouter is resource key of fake store
+	ResourceLocalRouter = "LocalRouter"
 	// ResourceMobileGateway is resource key of fake store
 	ResourceMobileGateway = "MobileGateway"
 	// ResourceNFS is resource key of fake store

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_store.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/zz_store.go
@@ -666,6 +666,34 @@ func putLoadBalancer(zone string, value *sacloud.LoadBalancer) {
 	ds().Put(ResourceLoadBalancer, zone, 0, value)
 }
 
+func getLocalRouter(zone string) []*sacloud.LocalRouter {
+	values := ds().List(ResourceLocalRouter, zone)
+	var ret []*sacloud.LocalRouter
+	for _, v := range values {
+		if v, ok := v.(*sacloud.LocalRouter); ok {
+			ret = append(ret, v)
+		}
+	}
+	return ret
+}
+
+func getLocalRouterByID(zone string, id types.ID) *sacloud.LocalRouter {
+	v := ds().Get(ResourceLocalRouter, zone, id)
+	if v, ok := v.(*sacloud.LocalRouter); ok {
+		return v
+	}
+	return nil
+}
+
+func putLocalRouter(zone string, value *sacloud.LocalRouter) {
+	var v interface{} = value
+	if id, ok := v.(accessor.ID); ok {
+		ds().Put(ResourceLocalRouter, zone, id.GetID(), value)
+		return
+	}
+	ds().Put(ResourceLocalRouter, zone, 0, value)
+}
+
 func getMobileGateway(zone string) []*sacloud.MobileGateway {
 	values := ds().List(ResourceMobileGateway, zone)
 	var ret []*sacloud.MobileGateway

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/hybrid_connection.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/hybrid_connection.go
@@ -12,7 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package libsacloud
+package naked
 
-// Version バージョン
-const Version = "2.0.0-rc5"
+import "github.com/sacloud/libsacloud/v2/sacloud/types"
+
+// HybridConnection ハイブリッドコネクション
+type HybridConnection struct {
+	ID       types.ID
+	Services []*HybridConnectionService
+}
+
+// HybridConnectionService ハイブリッドコネクションにて接続されているサービスの情報
+type HybridConnectionService struct {
+	ServiceCategory string
+	ServiceName     string
+	ServiceCode     string
+	CloudZone       string
+	IsMyself        bool
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/local_router.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/local_router.go
@@ -1,0 +1,132 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naked
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// LocalRouter ローカルルータ
+type LocalRouter struct {
+	ID           types.ID             `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name         string               `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description  string               `yaml:"description"`
+	Tags         types.Tags           `yaml:"tags"`
+	Icon         *Icon                `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt    *time.Time           `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt   *time.Time           `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Availability types.EAvailability  `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
+	Provider     *Provider            `json:",omitempty" yaml:"provider,omitempty" structs:",omitempty"`
+	Settings     *LocalRouterSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string               `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+	Status       *LocalRouterStatus   `json:",omitempty" yaml:"status" structs:",omitempty"`
+	ServiceClass string               `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettings セッティング
+type LocalRouterSettings struct {
+	LocalRouter *LocalRouterSetting `json:",omitempty" yaml:"local_router,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettingsUpdate ローカルルータ セッティング更新
+type LocalRouterSettingsUpdate struct {
+	Settings     *LocalRouterSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string               `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSetting セッティング
+type LocalRouterSetting struct {
+	Switch       *LocalRouterSettingSwitch        `yaml:"switch"`
+	Interface    *LocalRouterSettingInterface     `yaml:"interface"`
+	Peers        []*LocalRouterSettingPeer        `yaml:"peers"`
+	StaticRoutes []*LocalRouterSettingStaticRoute `yaml:"static_routes"`
+}
+
+// LocalRouterSettingSwitch ローカルルータのスイッチ設定
+type LocalRouterSettingSwitch struct {
+	Code     string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // リソースIDなど
+	Category string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // cloud/vps/専用サーバなどを表す
+	ZoneID   string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // クラウドの場合is1aなど Note: VPSの場合は数値型となる
+}
+
+// UnmarshalJSON ZoneIDに数値/文字列が混在する問題への対応
+func (l *LocalRouterSettingSwitch) UnmarshalJSON(b []byte) error {
+	type alias struct {
+		Code     string      `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // リソースIDなど
+		Category string      `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // cloud/vps/専用サーバなどを表す
+		ZoneID   interface{} `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // クラウドの場合is1aなど Note: VPSの場合は数値型となる
+	}
+
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	zoneID := ""
+	switch v := a.ZoneID.(type) {
+	case string:
+		zoneID = v
+	case int, int8, int16, int32, int64:
+		zoneID = fmt.Sprintf("%d", v)
+	case float32, float64:
+		zoneID = fmt.Sprintf("%d", int(v.(float64)))
+	}
+
+	*l = LocalRouterSettingSwitch{
+		Code:     a.Code,
+		Category: a.Category,
+		ZoneID:   zoneID,
+	}
+	return nil
+}
+
+// LocalRouterSettingInterface インターフェース設定
+type LocalRouterSettingInterface struct {
+	VirtualIPAddress string   `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	IPAddress        []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	NetworkMaskLen   int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	VRID             int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettingPeer ピア設定
+type LocalRouterSettingPeer struct {
+	ID          string `yaml:"id"` // 文字列でないとエラーになるためtypes.IDではなくstringとする
+	SecretKey   string `yaml:"secret_key"`
+	Enabled     bool   `yaml:"enabled"`
+	Description string `yaml:"description"`
+}
+
+// LocalRouterSettingStaticRoute スタティックルート
+type LocalRouterSettingStaticRoute struct {
+	Prefix  string `yaml:"prefix"`
+	NextHop string `yaml:"next_hop"`
+}
+
+// LocalRouterStatus ステータス
+type LocalRouterStatus struct {
+	SecretKeys []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+// LocalRouterHealth ローカルルータのヘルスチェック結果
+type LocalRouterHealth struct {
+	Peers []*struct {
+		ID     types.ID
+		Status types.EServerInstanceStatus
+		Routes []string
+	} `yaml:"peers"`
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/switch.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/switch.go
@@ -22,20 +22,21 @@ import (
 
 // Switch スイッチ
 type Switch struct {
-	ID          types.ID     `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
-	Name        string       `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
-	Description string       `yaml:"description"`
-	Tags        types.Tags   `yaml:"tags"`
-	Icon        *Icon        `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
-	CreatedAt   *time.Time   `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
-	ModifiedAt  *time.Time   `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
-	Scope       types.EScope `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
-	Subnet      *Subnet      `json:",omitempty" yaml:"subnet,omitempty" structs:",omitempty"`
-	UserSubnet  *UserSubnet  `json:",omitempty" yaml:"user_subnet,omitempty" structs:",omitempty"`
-	Zone        *Zone        `json:",omitempty" yaml:"zone,omitempty" structs:",omitempty"`
-	Internet    *Internet    `json:",omitempty" yaml:"internet,omitempty" structs:",omitempty"`
-	Subnets     []*Subnet    `json:",omitempty" yaml:"subnets,omitempty" structs:",omitempty"`
-	IPv6Nets    []*IPv6Net   `json:",omitempty" yaml:"ipv6nets,omitempty" structs:",omitempty"`
-	Bridge      *Bridge      `json:",omitempty" yaml:"bridge,omitempty" structs:",omitempty"`
-	ServerCount int          `json:",omitempty" yaml:"server_count,omitempty" structs:",omitempty"`
+	ID               types.ID          `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name             string            `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description      string            `yaml:"description"`
+	Tags             types.Tags        `yaml:"tags"`
+	Icon             *Icon             `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt        *time.Time        `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt       *time.Time        `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Scope            types.EScope      `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
+	Subnet           *Subnet           `json:",omitempty" yaml:"subnet,omitempty" structs:",omitempty"`
+	UserSubnet       *UserSubnet       `json:",omitempty" yaml:"user_subnet,omitempty" structs:",omitempty"`
+	Zone             *Zone             `json:",omitempty" yaml:"zone,omitempty" structs:",omitempty"`
+	Internet         *Internet         `json:",omitempty" yaml:"internet,omitempty" structs:",omitempty"`
+	Subnets          []*Subnet         `json:",omitempty" yaml:"subnets,omitempty" structs:",omitempty"`
+	IPv6Nets         []*IPv6Net        `json:",omitempty" yaml:"ipv6nets,omitempty" structs:",omitempty"`
+	Bridge           *Bridge           `json:",omitempty" yaml:"bridge,omitempty" structs:",omitempty"`
+	ServerCount      int               `json:",omitempty" yaml:"server_count,omitempty" structs:",omitempty"`
+	HybridConnection *HybridConnection `json:",omitempty" yaml:"hybrid_connection,omitempty" structs:",omitempty"`
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/trace/zz_api_tracer.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/trace/zz_api_tracer.go
@@ -96,6 +96,9 @@ func AddClientFactoryHooks() {
 	sacloud.AddClientFacotyHookFunc("LoadBalancer", func(in interface{}) interface{} {
 		return NewLoadBalancerTracer(in.(sacloud.LoadBalancerAPI))
 	})
+	sacloud.AddClientFacotyHookFunc("LocalRouter", func(in interface{}) interface{} {
+		return NewLocalRouterTracer(in.(sacloud.LocalRouterAPI))
+	})
 	sacloud.AddClientFacotyHookFunc("MobileGateway", func(in interface{}) interface{} {
 		return NewMobileGatewayTracer(in.(sacloud.MobileGatewayAPI))
 	})
@@ -5259,6 +5262,274 @@ func (t *LoadBalancerTracer) Status(ctx context.Context, zone string, id types.I
 	}
 
 	return result, err
+}
+
+/*************************************************
+* LocalRouterTracer
+*************************************************/
+
+// LocalRouterTracer is for trace LocalRouterOp operations
+type LocalRouterTracer struct {
+	Internal sacloud.LocalRouterAPI
+}
+
+// NewLocalRouterTracer creates new LocalRouterTracer instance
+func NewLocalRouterTracer(in sacloud.LocalRouterAPI) sacloud.LocalRouterAPI {
+	return &LocalRouterTracer{
+		Internal: in,
+	}
+}
+
+// Find is API call with trace log
+func (t *LocalRouterTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LocalRouterFindResult, error) {
+	log.Println("[TRACE] LocalRouterAPI.Find start")
+	targetArguments := struct {
+		Argconditions *sacloud.FindCondition `json:"conditions"`
+	}{
+		Argconditions: conditions,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Find end")
+	}()
+
+	result, err := t.Internal.Find(ctx, conditions)
+	targetResults := struct {
+		Result *sacloud.LocalRouterFindResult
+		Error  error
+	}{
+		Result: result,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return result, err
+}
+
+// Create is API call with trace log
+func (t *LocalRouterTracer) Create(ctx context.Context, param *sacloud.LocalRouterCreateRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Create start")
+	targetArguments := struct {
+		Argparam *sacloud.LocalRouterCreateRequest `json:"param"`
+	}{
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Create end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Create(ctx, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Read is API call with trace log
+func (t *LocalRouterTracer) Read(ctx context.Context, id types.ID) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Read start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Read end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Read(ctx, id)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Update is API call with trace log
+func (t *LocalRouterTracer) Update(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Update start")
+	targetArguments := struct {
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.LocalRouterUpdateRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Update end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Update(ctx, id, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// UpdateSettings is API call with trace log
+func (t *LocalRouterTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateSettingsRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                                  `json:"id"`
+		Argparam *sacloud.LocalRouterUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.UpdateSettings end")
+	}()
+
+	resultLocalRouter, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Delete is API call with trace log
+func (t *LocalRouterTracer) Delete(ctx context.Context, id types.ID) error {
+	log.Println("[TRACE] LocalRouterAPI.Delete start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Delete end")
+	}()
+
+	err := t.Internal.Delete(ctx, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// HealthStatus is API call with trace log
+func (t *LocalRouterTracer) HealthStatus(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	log.Println("[TRACE] LocalRouterAPI.HealthStatus start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.HealthStatus end")
+	}()
+
+	resultLocalRouterHealth, err := t.Internal.HealthStatus(ctx, id)
+	targetResults := struct {
+		LocalRouterHealth *sacloud.LocalRouterHealth
+		Error             error
+	}{
+		LocalRouterHealth: resultLocalRouterHealth,
+		Error:             err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouterHealth, err
+}
+
+// MonitorLocalRouter is API call with trace log
+func (t *LocalRouterTracer) MonitorLocalRouter(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LocalRouterActivity, error) {
+	log.Println("[TRACE] LocalRouterAPI.MonitorLocalRouter start")
+	targetArguments := struct {
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.MonitorLocalRouter end")
+	}()
+
+	resultLocalRouterActivity, err := t.Internal.MonitorLocalRouter(ctx, id, condition)
+	targetResults := struct {
+		LocalRouterActivity *sacloud.LocalRouterActivity
+		Error               error
+	}{
+		LocalRouterActivity: resultLocalRouterActivity,
+		Error:               err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouterActivity, err
 }
 
 /*************************************************

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_ops.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_ops.go
@@ -211,6 +211,14 @@ func init() {
 		}
 	})
 
+	SetClientFactoryFunc("LocalRouter", func(caller APICaller) interface{} {
+		return &LocalRouterOp{
+			Client:     caller,
+			PathSuffix: "api/cloud/1.1",
+			PathName:   "commonserviceitem",
+		}
+	})
+
 	SetClientFactoryFunc("MobileGateway", func(caller APICaller) interface{} {
 		return &MobileGatewayOp{
 			Client:     caller,
@@ -5797,6 +5805,306 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		return nil, err
 	}
 	return results, err
+}
+
+/*************************************************
+* LocalRouterOp
+*************************************************/
+
+// LocalRouterOp implements LocalRouterAPI interface
+type LocalRouterOp struct {
+	// Client APICaller
+	Client APICaller
+	// PathSuffix is used when building URL
+	PathSuffix string
+	// PathName is used when building URL
+	PathName string
+}
+
+// NewLocalRouterOp creates new LocalRouterOp instance
+func NewLocalRouterOp(caller APICaller) LocalRouterAPI {
+	return GetClientFactoryFunc("LocalRouter")(caller).(LocalRouterAPI)
+}
+
+// Find is API call
+func (o *LocalRouterOp) Find(ctx context.Context, conditions *FindCondition) (*LocalRouterFindResult, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"conditions": conditions,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformFindArgs(conditions)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformFindResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results, err
+}
+
+// Create is API call
+func (o *LocalRouterOp) Create(ctx context.Context, param *LocalRouterCreateRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformCreateArgs(param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformCreateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Read is API call
+func (o *LocalRouterOp) Read(ctx context.Context, id types.ID) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformReadResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Update is API call
+func (o *LocalRouterOp) Update(ctx context.Context, id types.ID, param *LocalRouterUpdateRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// UpdateSettings is API call
+func (o *LocalRouterOp) UpdateSettings(ctx context.Context, id types.ID, param *LocalRouterUpdateSettingsRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Delete is API call
+func (o *LocalRouterOp) Delete(ctx context.Context, id types.ID) error {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	// build results
+
+	return nil
+}
+
+// HealthStatus is API call
+func (o *LocalRouterOp) HealthStatus(ctx context.Context, id types.ID) (*LocalRouterHealth, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/health", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformHealthStatusResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouterHealth, nil
+}
+
+// MonitorLocalRouter is API call
+func (o *LocalRouterOp) MonitorLocalRouter(ctx context.Context, id types.ID, condition *MonitorCondition) (*LocalRouterActivity, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"condition":  condition,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/activity/localrouter/monitor", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorLocalRouterArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorLocalRouterResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouterActivity, nil
 }
 
 /*************************************************

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_transformers.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_transformers.go
@@ -3446,6 +3446,229 @@ func (o *LoadBalancerOp) transformStatusResults(data []byte) (*LoadBalancerStatu
 	return results, nil
 }
 
+func (o *LocalRouterOp) transformFindArgs(conditions *FindCondition) (*localRouterFindRequestEnvelope, error) {
+	if conditions == nil {
+		conditions = &FindCondition{}
+	}
+	var arg0 interface{} = conditions
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &localRouterFindRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformFindResults(data []byte) (*LocalRouterFindResult, error) {
+	nakedResponse := &localRouterFindResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &LocalRouterFindResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformCreateArgs(param *LocalRouterCreateRequest) (*localRouterCreateRequestEnvelope, error) {
+	if param == nil {
+		param = &LocalRouterCreateRequest{}
+	}
+	var arg0 interface{} = param
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &localRouterCreateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformCreateResults(data []byte) (*localRouterCreateResult, error) {
+	nakedResponse := &localRouterCreateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterCreateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformReadResults(data []byte) (*localRouterReadResult, error) {
+	nakedResponse := &localRouterReadResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterReadResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformUpdateArgs(id types.ID, param *LocalRouterUpdateRequest) (*localRouterUpdateRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LocalRouterUpdateRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterUpdateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformUpdateResults(data []byte) (*localRouterUpdateResult, error) {
+	nakedResponse := &localRouterUpdateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformUpdateSettingsArgs(id types.ID, param *LocalRouterUpdateSettingsRequest) (*localRouterUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LocalRouterUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformUpdateSettingsResults(data []byte) (*localRouterUpdateSettingsResult, error) {
+	nakedResponse := &localRouterUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformHealthStatusResults(data []byte) (*localRouterHealthStatusResult, error) {
+	nakedResponse := &localRouterHealthStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterHealthStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformMonitorLocalRouterArgs(id types.ID, condition *MonitorCondition) (*localRouterMonitorLocalRouterRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterMonitorLocalRouterRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformMonitorLocalRouterResults(data []byte) (*localRouterMonitorLocalRouterResult, error) {
+	nakedResponse := &localRouterMonitorLocalRouterResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterMonitorLocalRouterResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *MobileGatewayOp) transformFindArgs(conditions *FindCondition) (*mobileGatewayFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_apis.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_apis.go
@@ -352,6 +352,22 @@ type LoadBalancerAPI interface {
 }
 
 /*************************************************
+* LocalRouterAPI
+*************************************************/
+
+// LocalRouterAPI is interface for operate LocalRouter resource
+type LocalRouterAPI interface {
+	Find(ctx context.Context, conditions *FindCondition) (*LocalRouterFindResult, error)
+	Create(ctx context.Context, param *LocalRouterCreateRequest) (*LocalRouter, error)
+	Read(ctx context.Context, id types.ID) (*LocalRouter, error)
+	Update(ctx context.Context, id types.ID, param *LocalRouterUpdateRequest) (*LocalRouter, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *LocalRouterUpdateSettingsRequest) (*LocalRouter, error)
+	Delete(ctx context.Context, id types.ID) error
+	HealthStatus(ctx context.Context, id types.ID) (*LocalRouterHealth, error)
+	MonitorLocalRouter(ctx context.Context, id types.ID, condition *MonitorCondition) (*LocalRouterActivity, error)
+}
+
+/*************************************************
 * MobileGatewayAPI
 *************************************************/
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_envelopes.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_envelopes.go
@@ -1392,6 +1392,94 @@ type loadBalancerStatusResponseEnvelope struct {
 	LoadBalancer []*naked.LoadBalancerStatus `json:",omitempty"`
 }
 
+// localRouterFindRequestEnvelope is envelop of API request
+type localRouterFindRequestEnvelope struct {
+	Count   int             `mapconv:",omitempty"`
+	From    int             `mapconv:",omitempty"`
+	Sort    search.SortKeys `json:",omitempty" mapconv:",omitempty"`
+	Filter  search.Filter   `json:",omitempty" mapconv:",omitempty"`
+	Include []string        `json:",omitempty" mapconv:",omitempty"`
+	Exclude []string        `json:",omitempty" mapconv:",omitempty"`
+}
+
+// localRouterFindResponseEnvelope is envelop of API response
+type localRouterFindResponseEnvelope struct {
+	Total int `json:",omitempty"` // トータル件数
+	From  int `json:",omitempty"` // ページング開始ページ
+	Count int `json:",omitempty"` // 件数
+
+	CommonServiceItems []*naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterCreateRequestEnvelope is envelop of API request
+type localRouterCreateRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterCreateResponseEnvelope is envelop of API response
+type localRouterCreateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterReadResponseEnvelope is envelop of API response
+type localRouterReadResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateRequestEnvelope is envelop of API request
+type localRouterUpdateRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateResponseEnvelope is envelop of API response
+type localRouterUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateSettingsRequestEnvelope is envelop of API request
+type localRouterUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouterSettingsUpdate `json:",omitempty"`
+}
+
+// localRouterUpdateSettingsResponseEnvelope is envelop of API response
+type localRouterUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterHealthStatusResponseEnvelope is envelop of API response
+type localRouterHealthStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	LocalRouter *naked.LocalRouterHealth `json:",omitempty"`
+}
+
+// localRouterMonitorLocalRouterRequestEnvelope is envelop of API request
+type localRouterMonitorLocalRouterRequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// localRouterMonitorLocalRouterResponseEnvelope is envelop of API response
+type localRouterMonitorLocalRouterResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
+}
+
 // mobileGatewayFindRequestEnvelope is envelop of API request
 type mobileGatewayFindRequestEnvelope struct {
 	Count   int             `mapconv:",omitempty"`

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -12551,6 +12551,1017 @@ func (o *LoadBalancerServerStatus) SetCPS(v types.StringNumber) {
 }
 
 /*************************************************
+* LocalRouter
+*************************************************/
+
+// LocalRouter represents API parameter/response structure
+type LocalRouter struct {
+	ID           types.ID
+	Name         string `validate:"required"`
+	Description  string `validate:"min=0,max=512"`
+	Tags         types.Tags
+	Availability types.EAvailability
+	IconID       types.ID `mapconv:"Icon.ID"`
+	CreatedAt    time.Time
+	ModifiedAt   time.Time
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	SecretKeys   []string                  `mapconv:"Status.SecretKeys"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouter) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouter) setDefaults() interface{} {
+	return &struct {
+		ID           types.ID
+		Name         string `validate:"required"`
+		Description  string `validate:"min=0,max=512"`
+		Tags         types.Tags
+		Availability types.EAvailability
+		IconID       types.ID `mapconv:"Icon.ID"`
+		CreatedAt    time.Time
+		ModifiedAt   time.Time
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+		SecretKeys   []string                  `mapconv:"Status.SecretKeys"`
+	}{
+		ID:           o.GetID(),
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		Availability: o.GetAvailability(),
+		IconID:       o.GetIconID(),
+		CreatedAt:    o.GetCreatedAt(),
+		ModifiedAt:   o.GetModifiedAt(),
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+		SecretKeys:   o.GetSecretKeys(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouter) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouter) SetID(v types.ID) {
+	o.ID = v
+}
+
+// SetStringID .
+func (o *LocalRouter) SetStringID(id string) {
+	accessor.SetStringID(o, id)
+}
+
+// GetStringID .
+func (o *LocalRouter) GetStringID() string {
+	return accessor.GetStringID(o)
+}
+
+// SetInt64ID .
+func (o *LocalRouter) SetInt64ID(id int64) {
+	accessor.SetInt64ID(o, id)
+}
+
+// GetInt64ID .
+func (o *LocalRouter) GetInt64ID() int64 {
+	return accessor.GetInt64ID(o)
+}
+
+// GetName returns value of Name
+func (o *LocalRouter) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouter) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouter) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouter) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouter) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouter) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouter) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouter) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouter) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouter) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetAvailability returns value of Availability
+func (o *LocalRouter) GetAvailability() types.EAvailability {
+	return o.Availability
+}
+
+// SetAvailability sets value to Availability
+func (o *LocalRouter) SetAvailability(v types.EAvailability) {
+	o.Availability = v
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouter) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouter) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetCreatedAt returns value of CreatedAt
+func (o *LocalRouter) GetCreatedAt() time.Time {
+	return o.CreatedAt
+}
+
+// SetCreatedAt sets value to CreatedAt
+func (o *LocalRouter) SetCreatedAt(v time.Time) {
+	o.CreatedAt = v
+}
+
+// GetModifiedAt returns value of ModifiedAt
+func (o *LocalRouter) GetModifiedAt() time.Time {
+	return o.ModifiedAt
+}
+
+// SetModifiedAt sets value to ModifiedAt
+func (o *LocalRouter) SetModifiedAt(v time.Time) {
+	o.ModifiedAt = v
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouter) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouter) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouter) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouter) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouter) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouter) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouter) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouter) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouter) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouter) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetSecretKeys returns value of SecretKeys
+func (o *LocalRouter) GetSecretKeys() []string {
+	return o.SecretKeys
+}
+
+// SetSecretKeys sets value to SecretKeys
+func (o *LocalRouter) SetSecretKeys(v []string) {
+	o.SecretKeys = v
+}
+
+/*************************************************
+* LocalRouterSwitch
+*************************************************/
+
+// LocalRouterSwitch represents API parameter/response structure
+type LocalRouterSwitch struct {
+	Code     string
+	Category string
+	ZoneID   string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterSwitch) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterSwitch) setDefaults() interface{} {
+	return &struct {
+		Code     string
+		Category string
+		ZoneID   string
+	}{
+		Code:     o.GetCode(),
+		Category: o.GetCategory(),
+		ZoneID:   o.GetZoneID(),
+	}
+}
+
+// GetCode returns value of Code
+func (o *LocalRouterSwitch) GetCode() string {
+	return o.Code
+}
+
+// SetCode sets value to Code
+func (o *LocalRouterSwitch) SetCode(v string) {
+	o.Code = v
+}
+
+// GetCategory returns value of Category
+func (o *LocalRouterSwitch) GetCategory() string {
+	return o.Category
+}
+
+// SetCategory sets value to Category
+func (o *LocalRouterSwitch) SetCategory(v string) {
+	o.Category = v
+}
+
+// GetZoneID returns value of ZoneID
+func (o *LocalRouterSwitch) GetZoneID() string {
+	return o.ZoneID
+}
+
+// SetZoneID sets value to ZoneID
+func (o *LocalRouterSwitch) SetZoneID(v string) {
+	o.ZoneID = v
+}
+
+/*************************************************
+* LocalRouterInterface
+*************************************************/
+
+// LocalRouterInterface represents API parameter/response structure
+type LocalRouterInterface struct {
+	VirtualIPAddress string
+	IPAddress        []string
+	NetworkMaskLen   int
+	VRID             int
+}
+
+// Validate validates by field tags
+func (o *LocalRouterInterface) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterInterface) setDefaults() interface{} {
+	return &struct {
+		VirtualIPAddress string
+		IPAddress        []string
+		NetworkMaskLen   int
+		VRID             int
+	}{
+		VirtualIPAddress: o.GetVirtualIPAddress(),
+		IPAddress:        o.GetIPAddress(),
+		NetworkMaskLen:   o.GetNetworkMaskLen(),
+		VRID:             o.GetVRID(),
+	}
+}
+
+// GetVirtualIPAddress returns value of VirtualIPAddress
+func (o *LocalRouterInterface) GetVirtualIPAddress() string {
+	return o.VirtualIPAddress
+}
+
+// SetVirtualIPAddress sets value to VirtualIPAddress
+func (o *LocalRouterInterface) SetVirtualIPAddress(v string) {
+	o.VirtualIPAddress = v
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *LocalRouterInterface) GetIPAddress() []string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *LocalRouterInterface) SetIPAddress(v []string) {
+	o.IPAddress = v
+}
+
+// GetNetworkMaskLen returns value of NetworkMaskLen
+func (o *LocalRouterInterface) GetNetworkMaskLen() int {
+	return o.NetworkMaskLen
+}
+
+// SetNetworkMaskLen sets value to NetworkMaskLen
+func (o *LocalRouterInterface) SetNetworkMaskLen(v int) {
+	o.NetworkMaskLen = v
+}
+
+// GetVRID returns value of VRID
+func (o *LocalRouterInterface) GetVRID() int {
+	return o.VRID
+}
+
+// SetVRID sets value to VRID
+func (o *LocalRouterInterface) SetVRID(v int) {
+	o.VRID = v
+}
+
+/*************************************************
+* LocalRouterPeer
+*************************************************/
+
+// LocalRouterPeer represents API parameter/response structure
+type LocalRouterPeer struct {
+	ID          types.ID
+	SecretKey   string
+	Enabled     bool
+	Description string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterPeer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterPeer) setDefaults() interface{} {
+	return &struct {
+		ID          types.ID
+		SecretKey   string
+		Enabled     bool
+		Description string
+	}{
+		ID:          o.GetID(),
+		SecretKey:   o.GetSecretKey(),
+		Enabled:     o.GetEnabled(),
+		Description: o.GetDescription(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouterPeer) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouterPeer) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetSecretKey returns value of SecretKey
+func (o *LocalRouterPeer) GetSecretKey() string {
+	return o.SecretKey
+}
+
+// SetSecretKey sets value to SecretKey
+func (o *LocalRouterPeer) SetSecretKey(v string) {
+	o.SecretKey = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *LocalRouterPeer) GetEnabled() bool {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *LocalRouterPeer) SetEnabled(v bool) {
+	o.Enabled = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterPeer) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterPeer) SetDescription(v string) {
+	o.Description = v
+}
+
+/*************************************************
+* LocalRouterStaticRoute
+*************************************************/
+
+// LocalRouterStaticRoute represents API parameter/response structure
+type LocalRouterStaticRoute struct {
+	Prefix  string
+	NextHop string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterStaticRoute) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterStaticRoute) setDefaults() interface{} {
+	return &struct {
+		Prefix  string
+		NextHop string
+	}{
+		Prefix:  o.GetPrefix(),
+		NextHop: o.GetNextHop(),
+	}
+}
+
+// GetPrefix returns value of Prefix
+func (o *LocalRouterStaticRoute) GetPrefix() string {
+	return o.Prefix
+}
+
+// SetPrefix sets value to Prefix
+func (o *LocalRouterStaticRoute) SetPrefix(v string) {
+	o.Prefix = v
+}
+
+// GetNextHop returns value of NextHop
+func (o *LocalRouterStaticRoute) GetNextHop() string {
+	return o.NextHop
+}
+
+// SetNextHop sets value to NextHop
+func (o *LocalRouterStaticRoute) SetNextHop(v string) {
+	o.NextHop = v
+}
+
+/*************************************************
+* LocalRouterCreateRequest
+*************************************************/
+
+// LocalRouterCreateRequest represents API parameter/response structure
+type LocalRouterCreateRequest struct {
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        types.Tags
+	IconID      types.ID `mapconv:"Icon.ID"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterCreateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterCreateRequest) setDefaults() interface{} {
+	return &struct {
+		Name        string `validate:"required"`
+		Description string `validate:"min=0,max=512"`
+		Tags        types.Tags
+		IconID      types.ID `mapconv:"Icon.ID"`
+		Class       string   `mapconv:"Provider.Class"`
+	}{
+		Name:        o.GetName(),
+		Description: o.GetDescription(),
+		Tags:        o.GetTags(),
+		IconID:      o.GetIconID(),
+		Class:       "localrouter",
+	}
+}
+
+// GetName returns value of Name
+func (o *LocalRouterCreateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouterCreateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterCreateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterCreateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouterCreateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouterCreateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouterCreateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouterCreateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouterCreateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouterCreateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouterCreateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouterCreateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+/*************************************************
+* LocalRouterUpdateRequest
+*************************************************/
+
+// LocalRouterUpdateRequest represents API parameter/response structure
+type LocalRouterUpdateRequest struct {
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	Name         string                    `validate:"required"`
+	Description  string                    `validate:"min=0,max=512"`
+	Tags         types.Tags
+	IconID       types.ID `mapconv:"Icon.ID"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterUpdateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterUpdateRequest) setDefaults() interface{} {
+	return &struct {
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+		Name         string                    `validate:"required"`
+		Description  string                    `validate:"min=0,max=512"`
+		Tags         types.Tags
+		IconID       types.ID `mapconv:"Icon.ID"`
+	}{
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		IconID:       o.GetIconID(),
+	}
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouterUpdateRequest) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouterUpdateRequest) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouterUpdateRequest) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouterUpdateRequest) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterUpdateRequest) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterUpdateRequest) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouterUpdateRequest) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouterUpdateRequest) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouterUpdateRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouterUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetName returns value of Name
+func (o *LocalRouterUpdateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouterUpdateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterUpdateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterUpdateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouterUpdateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouterUpdateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouterUpdateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouterUpdateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouterUpdateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouterUpdateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouterUpdateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouterUpdateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+/*************************************************
+* LocalRouterUpdateSettingsRequest
+*************************************************/
+
+// LocalRouterUpdateSettingsRequest represents API parameter/response structure
+type LocalRouterUpdateSettingsRequest struct {
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouterUpdateSettingsRequest) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouterUpdateSettingsRequest) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouterUpdateSettingsRequest) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouterUpdateSettingsRequest) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterUpdateSettingsRequest) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterUpdateSettingsRequest) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouterUpdateSettingsRequest) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouterUpdateSettingsRequest) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouterUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouterUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* LocalRouterHealth
+*************************************************/
+
+// LocalRouterHealth represents API parameter/response structure
+type LocalRouterHealth struct {
+	Peers []*LocalRouterHealthPeer `mapconv:"[]Peers,recursive"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterHealth) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterHealth) setDefaults() interface{} {
+	return &struct {
+		Peers []*LocalRouterHealthPeer `mapconv:"[]Peers,recursive"`
+	}{
+		Peers: o.GetPeers(),
+	}
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterHealth) GetPeers() []*LocalRouterHealthPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterHealth) SetPeers(v []*LocalRouterHealthPeer) {
+	o.Peers = v
+}
+
+/*************************************************
+* LocalRouterHealthPeer
+*************************************************/
+
+// LocalRouterHealthPeer represents API parameter/response structure
+type LocalRouterHealthPeer struct {
+	ID     types.ID
+	Status types.EServerInstanceStatus
+	Routes []string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterHealthPeer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterHealthPeer) setDefaults() interface{} {
+	return &struct {
+		ID     types.ID
+		Status types.EServerInstanceStatus
+		Routes []string
+	}{
+		ID:     o.GetID(),
+		Status: o.GetStatus(),
+		Routes: o.GetRoutes(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouterHealthPeer) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouterHealthPeer) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetStatus returns value of Status
+func (o *LocalRouterHealthPeer) GetStatus() types.EServerInstanceStatus {
+	return o.Status
+}
+
+// SetStatus sets value to Status
+func (o *LocalRouterHealthPeer) SetStatus(v types.EServerInstanceStatus) {
+	o.Status = v
+}
+
+// GetRoutes returns value of Routes
+func (o *LocalRouterHealthPeer) GetRoutes() []string {
+	return o.Routes
+}
+
+// SetRoutes sets value to Routes
+func (o *LocalRouterHealthPeer) SetRoutes(v []string) {
+	o.Routes = v
+}
+
+/*************************************************
+* LocalRouterActivity
+*************************************************/
+
+// LocalRouterActivity represents API parameter/response structure
+type LocalRouterActivity struct {
+	Values []*MonitorLocalRouterValue `mapconv:"[]LocalRouter"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterActivity) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterActivity) setDefaults() interface{} {
+	return &struct {
+		Values []*MonitorLocalRouterValue `mapconv:"[]LocalRouter"`
+	}{
+		Values: o.GetValues(),
+	}
+}
+
+// GetValues returns value of Values
+func (o *LocalRouterActivity) GetValues() []*MonitorLocalRouterValue {
+	return o.Values
+}
+
+// SetValues sets value to Values
+func (o *LocalRouterActivity) SetValues(v []*MonitorLocalRouterValue) {
+	o.Values = v
+}
+
+/*************************************************
+* MonitorLocalRouterValue
+*************************************************/
+
+// MonitorLocalRouterValue represents API parameter/response structure
+type MonitorLocalRouterValue struct {
+	Time               time.Time `json:",omitempty" mapconv:",omitempty"`
+	ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+	SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MonitorLocalRouterValue) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MonitorLocalRouterValue) setDefaults() interface{} {
+	return &struct {
+		Time               time.Time `json:",omitempty" mapconv:",omitempty"`
+		ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+		SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Time:               o.GetTime(),
+		ReceiveBytesPerSec: o.GetReceiveBytesPerSec(),
+		SendBytesPerSec:    o.GetSendBytesPerSec(),
+	}
+}
+
+// GetTime returns value of Time
+func (o *MonitorLocalRouterValue) GetTime() time.Time {
+	return o.Time
+}
+
+// SetTime sets value to Time
+func (o *MonitorLocalRouterValue) SetTime(v time.Time) {
+	o.Time = v
+}
+
+// GetReceiveBytesPerSec returns value of ReceiveBytesPerSec
+func (o *MonitorLocalRouterValue) GetReceiveBytesPerSec() float64 {
+	return o.ReceiveBytesPerSec
+}
+
+// SetReceiveBytesPerSec sets value to ReceiveBytesPerSec
+func (o *MonitorLocalRouterValue) SetReceiveBytesPerSec(v float64) {
+	o.ReceiveBytesPerSec = v
+}
+
+// GetSendBytesPerSec returns value of SendBytesPerSec
+func (o *MonitorLocalRouterValue) GetSendBytesPerSec() float64 {
+	return o.SendBytesPerSec
+}
+
+// SetSendBytesPerSec sets value to SendBytesPerSec
+func (o *MonitorLocalRouterValue) SetSendBytesPerSec(v float64) {
+	o.SendBytesPerSec = v
+}
+
+/*************************************************
 * MobileGateway
 *************************************************/
 
@@ -22911,19 +23922,20 @@ func (o *SubnetIPAddress) SetIPAddress(v string) {
 
 // Switch represents API parameter/response structure
 type Switch struct {
-	ID             types.ID
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
-	Tags           types.Tags
-	IconID         types.ID `mapconv:"Icon.ID"`
-	CreatedAt      time.Time
-	ModifiedAt     time.Time
-	Scope          types.EScope
-	ServerCount    int
-	NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-	Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
-	BridgeID       types.ID        `mapconv:"Bridge.ID,omitempty"`
+	ID                 types.ID
+	Name               string `validate:"required"`
+	Description        string `validate:"min=0,max=512"`
+	Tags               types.Tags
+	IconID             types.ID `mapconv:"Icon.ID"`
+	CreatedAt          time.Time
+	ModifiedAt         time.Time
+	Scope              types.EScope
+	ServerCount        int
+	NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+	DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+	Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
+	BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
+	HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
 }
 
 // Validate validates by field tags
@@ -22934,33 +23946,35 @@ func (o *Switch) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *Switch) setDefaults() interface{} {
 	return &struct {
-		ID             types.ID
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
-		Tags           types.Tags
-		IconID         types.ID `mapconv:"Icon.ID"`
-		CreatedAt      time.Time
-		ModifiedAt     time.Time
-		Scope          types.EScope
-		ServerCount    int
-		NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-		Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
-		BridgeID       types.ID        `mapconv:"Bridge.ID,omitempty"`
+		ID                 types.ID
+		Name               string `validate:"required"`
+		Description        string `validate:"min=0,max=512"`
+		Tags               types.Tags
+		IconID             types.ID `mapconv:"Icon.ID"`
+		CreatedAt          time.Time
+		ModifiedAt         time.Time
+		Scope              types.EScope
+		ServerCount        int
+		NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+		DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+		Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
+		BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
+		HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
 	}{
-		ID:             o.GetID(),
-		Name:           o.GetName(),
-		Description:    o.GetDescription(),
-		Tags:           o.GetTags(),
-		IconID:         o.GetIconID(),
-		CreatedAt:      o.GetCreatedAt(),
-		ModifiedAt:     o.GetModifiedAt(),
-		Scope:          o.GetScope(),
-		ServerCount:    o.GetServerCount(),
-		NetworkMaskLen: o.GetNetworkMaskLen(),
-		DefaultRoute:   o.GetDefaultRoute(),
-		Subnets:        o.GetSubnets(),
-		BridgeID:       o.GetBridgeID(),
+		ID:                 o.GetID(),
+		Name:               o.GetName(),
+		Description:        o.GetDescription(),
+		Tags:               o.GetTags(),
+		IconID:             o.GetIconID(),
+		CreatedAt:          o.GetCreatedAt(),
+		ModifiedAt:         o.GetModifiedAt(),
+		Scope:              o.GetScope(),
+		ServerCount:        o.GetServerCount(),
+		NetworkMaskLen:     o.GetNetworkMaskLen(),
+		DefaultRoute:       o.GetDefaultRoute(),
+		Subnets:            o.GetSubnets(),
+		BridgeID:           o.GetBridgeID(),
+		HybridConnectionID: o.GetHybridConnectionID(),
 	}
 }
 
@@ -23132,6 +24146,16 @@ func (o *Switch) GetBridgeID() types.ID {
 // SetBridgeID sets value to BridgeID
 func (o *Switch) SetBridgeID(v types.ID) {
 	o.BridgeID = v
+}
+
+// GetHybridConnectionID returns value of HybridConnectionID
+func (o *Switch) GetHybridConnectionID() types.ID {
+	return o.HybridConnectionID
+}
+
+// SetHybridConnectionID sets value to HybridConnectionID
+func (o *Switch) SetHybridConnectionID(v types.ID) {
+	o.HybridConnectionID = v
 }
 
 /*************************************************

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_result.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_result.go
@@ -807,6 +807,57 @@ type LoadBalancerStatusResult struct {
 	Status []*LoadBalancerStatus `json:",omitempty" mapconv:"[]LoadBalancer,omitempty,recursive"`
 }
 
+// LocalRouterFindResult represents the Result of API
+type LocalRouterFindResult struct {
+	Total int `json:",omitempty"` // Total count of target resources
+	From  int `json:",omitempty"` // Current page number
+	Count int `json:",omitempty"` // Count of current page
+
+	LocalRouters []*LocalRouter `json:",omitempty" mapconv:"[]CommonServiceItems,omitempty,recursive"`
+}
+
+// localRouterCreateResult represents the Result of API
+type localRouterCreateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterReadResult represents the Result of API
+type localRouterReadResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterUpdateResult represents the Result of API
+type localRouterUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterUpdateSettingsResult represents the Result of API
+type localRouterUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterHealthStatusResult represents the Result of API
+type localRouterHealthStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouterHealth *LocalRouterHealth `json:",omitempty" mapconv:"LocalRouter,omitempty,recursive"`
+}
+
+// localRouterMonitorLocalRouterResult represents the Result of API
+type localRouterMonitorLocalRouterResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouterActivity *LocalRouterActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
 // MobileGatewayFindResult represents the Result of API
 type MobileGatewayFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/util
 github.com/prometheus/procfs/nfs
 github.com/prometheus/procfs/xfs
-# github.com/sacloud/libsacloud/v2 v2.0.0-rc4
+# github.com/sacloud/libsacloud/v2 v2.0.0-rc5.0.20200122082620-7e22416a425b
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv


### PR DESCRIPTION
This PR adds following metrics to the exporter:

| Metric                                     | Description                                                                            | Labels                                                                 |
| ------                                     | -----------                                                                            | ------                                                                 |
| sakuracloud_local_router_info              | A metric with a constant '1' value labeled by localRouter information                  | `id`, `name`, `tags`, `description`                                    |
| sakuracloud_local_router_up                | If 1 the localRouter is up and running, 0 otherwise                                    | `id`, `name`                                                           |
| sakuracloud_local_router_switch_info       | A metric with a constant '1' value labeled by localRouter connected switch information | `id`, `name`, `category`, `code`, `zone_id`                            |
| sakuracloud_local_router_network_info      | A metric with a constant '1' value labeled by network information of the localRouter   | `id`, `name`, `vip`, `ipaddress1`, `ipaddress2`, `nw_mask_len`, `vrid` |
| sakuracloud_local_router_static_route_info | A metric with a constant '1' value labeled by static route information                 | `id`, `name`, `route_index`, `prefix`, `next_hop`                      |
| sakuracloud_local_router_peer_info         | A metric with a constant '1' value labeled by peer information                         | `id`, `name`, `peer_index`, `peer_id`, `enabled`, `description`        |
| sakuracloud_local_router_peer_up           | If 1 the Peer is available, 0 otherwise                                                | `id`, `name`, `peer_index`, `peer_id`                                  |
| sakuracloud_local_router_receive_per_sec   | Receive bytes per seconds                                                              | `id`, `name`                                                           |
| sakuracloud_local_router_send_per_sec      | Send bytes per seconds                                                                 | `id`, `name`                                                           |
