### PR TITLE
VPCRouter: sakuracloud_vpc_router_cpu_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,10 @@ The exporter returns the following metrics:
 #### VPCRouter
 
 | Metric                                  | Description                                                          | Labels                                                                                                                                     |
-| ------                                  | -----------                                                          | ------                                                                                                                                     |
+|-----------------------------------------|----------------------------------------------------------------------| ------                                                                                                                                     |
 | sakuracloud_vpc_router_info             | A metric with a constant '1' value labeled by vpc_router information | `id`, `name`, `zone`, `plan`, `ha`, `vrid`, `vip`, `ipaddress1`, `ipaddress2`, `nw_mask_len`, `internet_connection`, `tags`, `description` |
 | sakuracloud_vpc_router_up               | If 1 the vpc_router is up and running, 0 otherwise                   | `id`, `name`, `zone`                                                                                                                       |
+| sakuracloud_vpc_router_cpu_time         | VPCRouter's CPU time(unit: ms)                                       | `id`, `name`, `zone`                                                                                                                       |
 | sakuracloud_vpc_router_session          | Current session count                                                | `id`, `name`, `zone`                                                                                                                       |
 | sakuracloud_vpc_router_dhcp_lease       | Current DHCPServer lease count                                       | `id`, `name`, `zone`                                                                                                                       |
 | sakuracloud_vpc_router_l2tp_session     | Current L2TP-IPsec session count                                     | `id`, `name`, `zone`                                                                                                                       |

--- a/collector/vpc_router_test.go
+++ b/collector/vpc_router_test.go
@@ -28,12 +28,14 @@ import (
 )
 
 type dummyVPCRouterClient struct {
-	find       []*iaas.VPCRouter
-	findErr    error
-	status     *sacloud.VPCRouterStatus
-	statusErr  error
-	monitor    *sacloud.MonitorInterfaceValue
-	monitorErr error
+	find          []*iaas.VPCRouter
+	findErr       error
+	status        *sacloud.VPCRouterStatus
+	statusErr     error
+	monitor       *sacloud.MonitorInterfaceValue
+	monitorErr    error
+	monitorCPU    *sacloud.MonitorCPUTimeValue
+	monitorCPUErr error
 }
 
 func (d *dummyVPCRouterClient) Find(ctx context.Context) ([]*iaas.VPCRouter, error) {
@@ -46,6 +48,10 @@ func (d *dummyVPCRouterClient) MonitorNIC(ctx context.Context, zone string, id t
 	return d.monitor, d.monitorErr
 }
 
+func (d *dummyVPCRouterClient) MonitorCPU(ctx context.Context, zone string, id types.ID, end time.Time) (*sacloud.MonitorCPUTimeValue, error) {
+	return d.monitorCPU, d.monitorCPUErr
+}
+
 func TestVPCRouterCollector_Describe(t *testing.T) {
 	initLoggerAndErrors()
 	c := NewVPCRouterCollector(context.Background(), testLogger, testErrors, &dummyVPCRouterClient{})
@@ -54,6 +60,7 @@ func TestVPCRouterCollector_Describe(t *testing.T) {
 	require.Len(t, descs, len([]*prometheus.Desc{
 		c.Up,
 		c.VPCRouterInfo,
+		c.CPUTime,
 		c.SessionCount,
 		c.DHCPLeaseCount,
 		c.L2TPSessionCount,

--- a/iaas/vpc_router.go
+++ b/iaas/vpc_router.go
@@ -31,6 +31,7 @@ type VPCRouterClient interface {
 	Find(ctx context.Context) ([]*VPCRouter, error)
 	Status(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouterStatus, error)
 	MonitorNIC(ctx context.Context, zone string, id types.ID, index int, end time.Time) (*sacloud.MonitorInterfaceValue, error)
+	MonitorCPU(ctx context.Context, zone string, id types.ID, end time.Time) (*sacloud.MonitorCPUTimeValue, error)
 }
 
 func getVPCRouterClient(caller sacloud.APICaller, zones []string) VPCRouterClient {
@@ -80,6 +81,14 @@ func (c *vpcRouterClient) MonitorNIC(ctx context.Context, zone string, id types.
 		return nil, err
 	}
 	return monitorInterfaceValue(mvs.Values), nil
+}
+
+func (c *vpcRouterClient) MonitorCPU(ctx context.Context, zone string, id types.ID, end time.Time) (*sacloud.MonitorCPUTimeValue, error) {
+	mvs, err := c.client.MonitorCPU(ctx, zone, id, monitorCondition(end))
+	if err != nil {
+		return nil, err
+	}
+	return monitorCPUTimeValue(mvs.Values), nil
 }
 
 func (c *vpcRouterClient) Status(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouterStatus, error) {


### PR DESCRIPTION
closes #56 

Example:

```console
# HELP sakuracloud_vpc_router_cpu_time VPCRouter's CPU time(unit: ms)
# TYPE sakuracloud_vpc_router_cpu_time gauge
sakuracloud_vpc_router_cpu_time{id="111111111111",name="example",zone="is1a"} 40 1638844800000
```