### PR TITLE
メンテナンス情報のみ取得できるオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,28 @@ $ docker run -p 9542:9542 -e SAKURACLOUD_ACCESS_TOKEN=<YOUR-TOKEN> -e SAKURACLOU
 
 ### Flags
 
-| Flag / Environment Variable                    | Required | Default    | Description                                          |
-| --------------------------------------------   | -------- | ---------- | -------------------------                            |
-| `--token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯        |            | API Key(Token)                                       |
-| `--secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯        |            | API Key(Secret)                                      |
-| `--ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                   |
-| `--webaddr` / `WEB_ADDR`                       |          | `:9542`    | Exporter's listen address                            |
-| `--webpath`/ `WEB_PATH`                        |          | `/metrics` | Metrics request path                                 |
-| `--no-collector.auto-backup`                   |          | `false`    | Disable the AutoBackup collector                     |
-| `--no-collector.coupon`                        |          | `false`    | Disable the Coupon collector                         |
-| `--no-collector.database`                      |          | `false`    | Disable the Database collector                       |
-| `--no-collector.esme`                          |          | `false`    | Disable the ESME collector                           |
-| `--no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector        |
-| `--no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                   |
-| `--no-collector.local-router`                  |          | `false`    | Disable the LocalRouter collector                    |
-| `--no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                  |
-| `--no-collector.nfs`                           |          | `false`    | Disable the NFS collector                            |
-| `--no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector |
-| `--no-collector.server`                        |          | `false`    | Disable the Server collector                         |
-| `--no-collector.sim`                           |          | `false`    | Disable the SIM collector                            |
-| `--no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                      |
-| `--no-collector.zone`                          |          | `false`    | Disable the Zone collector                           |
+| Flag / Environment Variable                    | Required | Default    | Description                                                     |
+| --------------------------------------------   | -------- | ---------- | -------------------------                                       |
+| `--token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯       |            | API Key(Token)                                                  |
+| `--secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯       |            | API Key(Secret)                                                 |
+| `--ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                              |
+| `--webaddr` / `WEB_ADDR`                       |          | `:9542`    | Exporter's listen address                                       |
+| `--webpath`/ `WEB_PATH`                        |          | `/metrics` | Metrics request path                                            |
+| `--no-collector.auto-backup`                   |          | `false`    | Disable the AutoBackup collector                                |
+| `--no-collector.coupon`                        |          | `false`    | Disable the Coupon collector                                    |
+| `--no-collector.database`                      |          | `false`    | Disable the Database collector                                  |
+| `--no-collector.esme`                          |          | `false`    | Disable the ESME collector                                      |
+| `--no-collector.internet`                      |          | `false`    | Disable the Internet(Switch+Router) collector                   |
+| `--no-collector.load-balancer`                 |          | `false`    | Disable the LoadBalancer collector                              |
+| `--no-collector.local-router`                  |          | `false`    | Disable the LocalRouter collector                               |
+| `--no-collector.mobile-gateway`                |          | `false`    | Disable the MobileGateway collector                             |
+| `--no-collector.nfs`                           |          | `false`    | Disable the NFS collector                                       |
+| `--no-collector.proxy-lb`                      |          | `false`    | Disable the ProxyLB(Enhanced LoadBalancer) collector            |
+| `--no-collector.server`                        |          | `false`    | Disable the Server collector                                    |
+| `--no-collector.server.except-maintenance`     |          | `false`    | Disable the Server collector except for maintenance information |
+| `--no-collector.sim`                           |          | `false`    | Disable the SIM collector                                       |
+| `--no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                                 |
+| `--no-collector.zone`                          |          | `false`    | Disable the Zone collector                                      |
 
 
 #### Flags for debug

--- a/collector/server.go
+++ b/collector/server.go
@@ -226,25 +226,7 @@ func (c *ServerCollector) Collect(ch chan<- prometheus.Metric) {
 					float64(server.GetMemoryGB()),
 					serverLabels...,
 				)
-			}
 
-			// maintenance info
-			var maintenanceScheduled float64
-			if server.InstanceHostInfoURL != "" {
-				maintenanceScheduled = 1.0
-				wg.Add(1)
-				go func() {
-					c.collectMaintenanceInfo(ch, server)
-					wg.Done()
-				}()
-			}
-			ch <- prometheus.MustNewConstMetric(
-				c.MaintenanceScheduled,
-				prometheus.GaugeValue,
-				maintenanceScheduled,
-				serverLabels...,
-			)
-			if !c.maintOnly {
 				wg.Add(len(server.Disks))
 				for i := range server.Disks {
 					go func(i int) {
@@ -299,6 +281,23 @@ func (c *ServerCollector) Collect(ch chan<- prometheus.Metric) {
 					}
 				}
 			}
+
+			// maintenance info
+			var maintenanceScheduled float64
+			if server.InstanceHostInfoURL != "" {
+				maintenanceScheduled = 1.0
+				wg.Add(1)
+				go func() {
+					c.collectMaintenanceInfo(ch, server)
+					wg.Done()
+				}()
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.MaintenanceScheduled,
+				prometheus.GaugeValue,
+				maintenanceScheduled,
+				serverLabels...,
+			)
 		}(servers[i])
 	}
 

--- a/collector/server.go
+++ b/collector/server.go
@@ -30,10 +30,11 @@ import (
 
 // ServerCollector collects metrics about all servers.
 type ServerCollector struct {
-	ctx    context.Context
-	logger log.Logger
-	errors *prometheus.CounterVec
-	client iaas.ServerClient
+	ctx       context.Context
+	logger    log.Logger
+	errors    *prometheus.CounterVec
+	client    iaas.ServerClient
+	maintOnly bool
 
 	Up         *prometheus.Desc
 	ServerInfo *prometheus.Desc
@@ -57,7 +58,7 @@ type ServerCollector struct {
 }
 
 // NewServerCollector returns a new ServerCollector.
-func NewServerCollector(ctx context.Context, logger log.Logger, errors *prometheus.CounterVec, client iaas.ServerClient) *ServerCollector {
+func NewServerCollector(ctx context.Context, logger log.Logger, errors *prometheus.CounterVec, client iaas.ServerClient, maintenanceOnly bool) *ServerCollector {
 	errors.WithLabelValues("server").Add(0)
 
 	serverLabels := []string{"id", "name", "zone"}
@@ -69,10 +70,11 @@ func NewServerCollector(ctx context.Context, logger log.Logger, errors *promethe
 	maintenanceInfoLabel := append(serverLabels, "info_url", "info_title", "description", "start_date", "end_date")
 
 	return &ServerCollector{
-		ctx:    ctx,
-		logger: logger,
-		errors: errors,
-		client: client,
+		ctx:       ctx,
+		logger:    logger,
+		errors:    errors,
+		client:    client,
+		maintOnly: maintenanceOnly,
 		Up: prometheus.NewDesc(
 			"sakuracloud_server_up",
 			"If 1 the server is up and running, 0 otherwise",
@@ -195,34 +197,36 @@ func (c *ServerCollector) Collect(ch chan<- prometheus.Metric) {
 
 			serverLabels := c.serverLabels(server)
 
-			var up float64
-			if server.InstanceStatus.IsUp() {
-				up = 1.0
+			if !c.maintOnly {
+				var up float64
+				if server.InstanceStatus.IsUp() {
+					up = 1.0
+				}
+				ch <- prometheus.MustNewConstMetric(
+					c.Up,
+					prometheus.GaugeValue,
+					up,
+					serverLabels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.ServerInfo,
+					prometheus.GaugeValue,
+					float64(1.0),
+					c.serverInfoLabels(server)...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.CPUs,
+					prometheus.GaugeValue,
+					float64(server.GetCPU()),
+					serverLabels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.Memories,
+					prometheus.GaugeValue,
+					float64(server.GetMemoryGB()),
+					serverLabels...,
+				)
 			}
-			ch <- prometheus.MustNewConstMetric(
-				c.Up,
-				prometheus.GaugeValue,
-				up,
-				serverLabels...,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				c.ServerInfo,
-				prometheus.GaugeValue,
-				float64(1.0),
-				c.serverInfoLabels(server)...,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				c.CPUs,
-				prometheus.GaugeValue,
-				float64(server.GetCPU()),
-				serverLabels...,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				c.Memories,
-				prometheus.GaugeValue,
-				float64(server.GetMemoryGB()),
-				serverLabels...,
-			)
 
 			// maintenance info
 			var maintenanceScheduled float64
@@ -240,58 +244,59 @@ func (c *ServerCollector) Collect(ch chan<- prometheus.Metric) {
 				maintenanceScheduled,
 				serverLabels...,
 			)
-
-			wg.Add(len(server.Disks))
-			for i := range server.Disks {
-				go func(i int) {
-					c.collectDiskInfo(ch, server, i)
-					wg.Done()
-				}(i)
-			}
-
-			for i := range server.Interfaces {
-				ch <- prometheus.MustNewConstMetric(
-					c.NICInfo,
-					prometheus.GaugeValue,
-					float64(1.0),
-					c.nicInfoLabels(server, i)...,
-				)
-
-				bandwidth := float64(server.BandWidthAt(i))
-				ch <- prometheus.MustNewConstMetric(
-					c.NICBandwidth,
-					prometheus.GaugeValue,
-					bandwidth,
-					c.nicLabels(server, i)...,
-				)
-			}
-
-			if server.InstanceStatus.IsUp() {
-				// collect metrics per resources under server
-				now := time.Now()
-				// CPU-TIME
-				wg.Add(1)
-				go func() {
-					c.collectCPUTime(ch, server, now)
-					wg.Done()
-				}()
-
-				// Disks
+			if !c.maintOnly {
 				wg.Add(len(server.Disks))
 				for i := range server.Disks {
 					go func(i int) {
-						c.collectDiskMetrics(ch, server, i, now)
+						c.collectDiskInfo(ch, server, i)
 						wg.Done()
 					}(i)
 				}
 
-				// NICs
-				wg.Add(len(server.Interfaces))
 				for i := range server.Interfaces {
-					go func(i int) {
-						c.collectNICMetrics(ch, server, i, now)
+					ch <- prometheus.MustNewConstMetric(
+						c.NICInfo,
+						prometheus.GaugeValue,
+						float64(1.0),
+						c.nicInfoLabels(server, i)...,
+					)
+
+					bandwidth := float64(server.BandWidthAt(i))
+					ch <- prometheus.MustNewConstMetric(
+						c.NICBandwidth,
+						prometheus.GaugeValue,
+						bandwidth,
+						c.nicLabels(server, i)...,
+					)
+				}
+
+				if server.InstanceStatus.IsUp() {
+					// collect metrics per resources under server
+					now := time.Now()
+					// CPU-TIME
+					wg.Add(1)
+					go func() {
+						c.collectCPUTime(ch, server, now)
 						wg.Done()
-					}(i)
+					}()
+
+					// Disks
+					wg.Add(len(server.Disks))
+					for i := range server.Disks {
+						go func(i int) {
+							c.collectDiskMetrics(ch, server, i, now)
+							wg.Done()
+						}(i)
+					}
+
+					// NICs
+					wg.Add(len(server.Interfaces))
+					for i := range server.Interfaces {
+						go func(i int) {
+							c.collectNICMetrics(ch, server, i, now)
+							wg.Done()
+						}(i)
+					}
 				}
 			}
 		}(servers[i])

--- a/config/config.go
+++ b/config/config.go
@@ -38,20 +38,21 @@ type Config struct {
 	WebPath   string   `arg:"env:WEB_PATH"`
 	RateLimit int      `arg:"env:SAKURACLOUD_RATE_LIMIT" help:"Rate limit per second for SakuraCloud API calls"`
 
-	NoCollectorAutoBackup    bool `arg:"--no-collector.auto-backup" help:"Disable the AutoBackup collector"`
-	NoCollectorCoupon        bool `arg:"--no-collector.coupon" help:"Disable the Coupon collector"`
-	NoCollectorDatabase      bool `arg:"--no-collector.database" help:"Disable the Database collector"`
-	NoCollectorESME          bool `arg:"--no-collector.esme" help:"Disable the ESME collector"`
-	NoCollectorInternet      bool `arg:"--no-collector.internet" help:"Disable the Internet(Switch+Router) collector"`
-	NoCollectorLoadBalancer  bool `arg:"--no-collector.load-balancer" help:"Disable the LoadBalancer collector"`
-	NoCollectorLocalRouter   bool `arg:"--no-collector.local-router" help:"Disable the LocalRouter collector"`
-	NoCollectorMobileGateway bool `arg:"--no-collector.mobile-gateway" help:"Disable the MobileGateway collector"`
-	NoCollectorNFS           bool `arg:"--no-collector.nfs" help:"Disable the NFS collector"`
-	NoCollectorProxyLB       bool `arg:"--no-collector.proxy-lb" help:"Disable the ProxyLB(Enhanced LoadBalancer) collector"`
-	NoCollectorServer        bool `arg:"--no-collector.server" help:"Disable the Server collector"`
-	NoCollectorSIM           bool `arg:"--no-collector.sim" help:"Disable the SIM collector"`
-	NoCollectorVPCRouter     bool `arg:"--no-collector.vpc-router" help:"Disable the VPCRouter collector"`
-	NoCollectorZone          bool `arg:"--no-collector.zone" help:"Disable the Zone collector"`
+	NoCollectorAutoBackup              bool `arg:"--no-collector.auto-backup" help:"Disable the AutoBackup collector"`
+	NoCollectorCoupon                  bool `arg:"--no-collector.coupon" help:"Disable the Coupon collector"`
+	NoCollectorDatabase                bool `arg:"--no-collector.database" help:"Disable the Database collector"`
+	NoCollectorESME                    bool `arg:"--no-collector.esme" help:"Disable the ESME collector"`
+	NoCollectorInternet                bool `arg:"--no-collector.internet" help:"Disable the Internet(Switch+Router) collector"`
+	NoCollectorLoadBalancer            bool `arg:"--no-collector.load-balancer" help:"Disable the LoadBalancer collector"`
+	NoCollectorLocalRouter             bool `arg:"--no-collector.local-router" help:"Disable the LocalRouter collector"`
+	NoCollectorMobileGateway           bool `arg:"--no-collector.mobile-gateway" help:"Disable the MobileGateway collector"`
+	NoCollectorNFS                     bool `arg:"--no-collector.nfs" help:"Disable the NFS collector"`
+	NoCollectorProxyLB                 bool `arg:"--no-collector.proxy-lb" help:"Disable the ProxyLB(Enhanced LoadBalancer) collector"`
+	NoCollectorServer                  bool `arg:"--no-collector.server" help:"Disable the Server collector"`
+	NoCollectorServerExceptMaintenance bool `arg:"--no-collector.server.except-maintenance" help:"Disable the Server collector except for maintenance information"`
+	NoCollectorSIM                     bool `arg:"--no-collector.sim" help:"Disable the SIM collector"`
+	NoCollectorVPCRouter               bool `arg:"--no-collector.vpc-router" help:"Disable the VPCRouter collector"`
+	NoCollectorZone                    bool `arg:"--no-collector.zone" help:"Disable the Zone collector"`
 }
 
 func InitConfig() (Config, error) {
@@ -74,6 +75,9 @@ func InitConfig() (Config, error) {
 	}
 	if c.RateLimit > maximumRateLimit {
 		return c, fmt.Errorf("--ratelimit must be 1 to %d", maximumRateLimit)
+	}
+	if c.NoCollectorServerExceptMaintenance && c.NoCollectorServer {
+		return c, fmt.Errorf("--no-collector.server.except-maintenance enabled and --no-collector-server are both enabled")
 	}
 
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 		r.MustRegister(collector.NewProxyLBCollector(ctx, logger, errs, client.ProxyLB))
 	}
 	if !c.NoCollectorServer {
-		r.MustRegister(collector.NewServerCollector(ctx, logger, errs, client.Server))
+		r.MustRegister(collector.NewServerCollector(ctx, logger, errs, client.Server, c.NoCollectorServerExceptMaintenance))
 	}
 	if !c.NoCollectorSIM {
 		r.MustRegister(collector.NewSIMCollector(ctx, logger, errs, client.SIM))


### PR DESCRIPTION
# 概要
CPUやメモリ等のサーバーアクティビティを取得せずにメンテナンス情報のみ収集することができるオプション `--no-collector.server.except-maintenance` を追加しました。

# 背景
さくらのクラウド上に多数のサーバーをデプロイしている場合、server collectorによるサーバーアクティビティの取得に時間がかかり、台数によってはScrape Durationが1分超にまでなってしまう。 `--no-collector.server` することでメトリクス取得時間は減少するが、サーバーを運用するにあたって有用なメンテナンス情報まで取得できなくなってしまうため、サーバーアクティビティを取得せずにメンテナンス情報のみ収集できるオプションを追加しました。


