### PR TITLE
APIクライアントのパラメータでデフォルト値を利用

### DIFF
--- a/platform/client.go
+++ b/platform/client.go
@@ -55,12 +55,8 @@ func NewSakuraCloudClient(c config.Config, version string) *Client {
 		Options: &client.Options{
 			AccessToken:          c.Token,
 			AccessTokenSecret:    c.Secret,
-			HttpRequestTimeout:   0,
 			HttpRequestRateLimit: c.RateLimit,
 			UserAgent:            fmt.Sprintf("sakuracloud_exporter/%s", version),
-			RetryMax:             9,
-			RetryWaitMin:         1,
-			RetryWaitMax:         5,
 			Trace:                c.Trace,
 		},
 		TraceAPI:      c.Debug,


### PR DESCRIPTION
従来はデフォルト値を明示していたがAPIクライアント側のデフォルト値で十分と思われるため指定しないようにする