### PR TITLE
ウェブアクセラレータ対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ docker run -p 9542:9542 -e SAKURACLOUD_ACCESS_TOKEN=<YOUR-TOKEN> -e SAKURACLOU
 ### Flags
 
 | Flag / Environment Variable                    | Required | Default    | Description                                                     |
-| --------------------------------------------   | -------- | ---------- | -------------------------                                       |
+|------------------------------------------------| -------- | ---------- | -------------------------                                       |
 | `--token` / `SAKURACLOUD_ACCESS_TOKEN`         | ◯       |            | API Key(Token)                                                  |
 | `--secret` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` | ◯       |            | API Key(Secret)                                                 |
 | `--ratelimit`/ `SAKURACLOUD_RATE_LIMIT`        |          | `5`        | API request rate limit(maximum:10)                              |
@@ -64,6 +64,7 @@ $ docker run -p 9542:9542 -e SAKURACLOUD_ACCESS_TOKEN=<YOUR-TOKEN> -e SAKURACLOU
 | `--no-collector.sim`                           |          | `false`    | Disable the SIM collector                                       |
 | `--no-collector.vpc-router`                    |          | `false`    | Disable the VPCRouter collector                                 |
 | `--no-collector.zone`                          |          | `false`    | Disable the Zone collector                                      |
+| `--no-collector.webaccel`                      |          | `false`    | Disable the WebAccel collector                                      |
 
 
 #### Flags for debug
@@ -81,7 +82,7 @@ Example fake store file(JSON) is here[examples/fake/generate-fake-store-json/exa
 The exporter returns the following metrics:
 
 | Resource Type                   | Metric Name Prefix           |
-| ------                          | -----------                  |
+|---------------------------------|------------------------------|
 | [AutoBackup](#autobackup)       | sakuracloud_auto_backup_*    |
 | [Coupon](#coupon)               | sakuracloud_coupon_*         |
 | [Database](#database)           | sakuracloud_database_*       |
@@ -96,6 +97,7 @@ The exporter returns the following metrics:
 | [SIM](#sim)                     | sakuracloud_sim_*            |
 | [VPCRouter](#vpcrouter)         | sakuracloud_vpc_router_*     |
 | [Zone](#zone)                   | sakuracloud_zone_*           |
+| [WebAccel](#webaccel)           | webaccel_*                   |
 | [Exporter](#exporter)           | sakuracloud_exporter_*       |
 
 
@@ -271,6 +273,20 @@ The exporter returns the following metrics:
 | Metric                | Description                                                    | Labels                                                  |
 | ------                | -----------                                                    | ------                                                  |
 | sakuracloud_zone_info | A metric with a constant '1' value labeled by zone information | `id`, `name`, `description`, `region_id`, `region_name` |
+
+#### WebAccel
+
+| Metric                         | Description                                               | Labels                                             |
+|--------------------------------|-----------------------------------------------------------|----------------------------------------------------|
+| webaccel_site_info             | A metric with a constant '1' value                        | `id`, `name`, `domain_type`, `domain`, `subdomain` |
+| webaccel_access_count          | Access count                                              | `id` |
+| webaccel_bytes_sent            | Bytes sent                                                | `id` |
+| webaccel_cache_miss_bytes_sent | Cache miss bytes sent                                     | `id` |
+| webaccel_cache_hit_ratio       | Cache hit ratio                                           | `id` |
+| webaccel_bytes_cache_hit_ratio | Bytes cache hit ratio                                     | `id` |
+| webaccel_price                 | Price                                                     | `id` |
+| webaccel_cert_expire           | Certificate expiration date in seconds since epoch (1970) | `id` |
+
 
 #### Exporter
 

--- a/collector/webaccel.go
+++ b/collector/webaccel.go
@@ -1,0 +1,198 @@
+// Copyright 2019-2022 The sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sacloud/sakuracloud_exporter/platform"
+)
+
+// WebAccelCollector collects metrics about the webaccel's sites.
+type WebAccelCollector struct {
+	ctx    context.Context
+	logger log.Logger
+	errors *prometheus.CounterVec
+	client platform.WebAccelClient
+
+	SiteInfo           *prometheus.Desc
+	AccessCount        *prometheus.Desc
+	BytesSent          *prometheus.Desc
+	CacheMissBytesSent *prometheus.Desc
+	CacheHitRatio      *prometheus.Desc
+	BytesCacheHitRatio *prometheus.Desc
+	Price              *prometheus.Desc
+
+	CertificateExpireDate *prometheus.Desc
+}
+
+// NewWebAccelCollector returns a new WebAccelCollector.
+func NewWebAccelCollector(ctx context.Context, logger log.Logger, errors *prometheus.CounterVec, client platform.WebAccelClient) *WebAccelCollector {
+	errors.WithLabelValues("webaccel").Add(0)
+
+	labels := []string{"id"}
+
+	return &WebAccelCollector{
+		ctx:    ctx,
+		logger: logger,
+		errors: errors,
+		client: client,
+		SiteInfo: prometheus.NewDesc(
+			"webaccel_site_info",
+			"A metric with a constant '1' value labeled by id, name, domain_type, domain, subdomain",
+			[]string{"id", "name", "domain_type", "domain", "subdomain"}, nil,
+		),
+		AccessCount: prometheus.NewDesc(
+			"webaccel_access_count",
+			"",
+			labels, nil,
+		),
+		BytesSent: prometheus.NewDesc(
+			"webaccel_bytes_sent",
+			"",
+			labels, nil,
+		),
+		CacheMissBytesSent: prometheus.NewDesc(
+			"webaccel_cache_miss_bytes_sent",
+			"",
+			labels, nil,
+		),
+		CacheHitRatio: prometheus.NewDesc(
+			"webaccel_cache_hit_ratio",
+			"",
+			labels, nil,
+		),
+		BytesCacheHitRatio: prometheus.NewDesc(
+			"webaccel_bytes_cache_hit_ratio",
+			"",
+			labels, nil,
+		),
+		Price: prometheus.NewDesc(
+			"webaccel_price",
+			"",
+			labels, nil,
+		),
+		CertificateExpireDate: prometheus.NewDesc(
+			"webaccel_cert_expire",
+			"Certificate expiration date in seconds since epoch (1970)",
+			labels, nil,
+		),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector.
+func (c *WebAccelCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.SiteInfo
+	ch <- c.AccessCount
+	ch <- c.BytesSent
+	ch <- c.CacheMissBytesSent
+	ch <- c.CacheHitRatio
+	ch <- c.BytesCacheHitRatio
+	ch <- c.Price
+	ch <- c.CertificateExpireDate
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+func (c *WebAccelCollector) Collect(ch chan<- prometheus.Metric) {
+	sites, err := c.client.Find(c.ctx)
+	if err != nil {
+		c.errors.WithLabelValues("webaccel").Add(1)
+		level.Warn(c.logger).Log( // nolint
+			"msg", "can't get webAccel info",
+			"err", err,
+		)
+		return
+	}
+
+	for _, site := range sites {
+		labels := []string{
+			site.ID,
+			site.Name,
+			site.DomainType,
+			site.Domain,
+			site.Subdomain,
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.SiteInfo,
+			prometheus.GaugeValue,
+			1.0,
+			labels...,
+		)
+
+		if site.HasCertificate {
+			ch <- prometheus.MustNewConstMetric(
+				c.CertificateExpireDate,
+				prometheus.GaugeValue,
+				float64(site.CertValidNotAfter),
+				[]string{site.ID}...,
+			)
+		}
+	}
+
+	usage, err := c.client.Usage(c.ctx)
+	if err != nil {
+		c.errors.WithLabelValues("webaccel").Add(1)
+		level.Warn(c.logger).Log( // nolint
+			"msg", "can't get webAccel monthly usage",
+			"err", err,
+		)
+		return
+	}
+	for _, u := range usage.MonthlyUsages {
+		labels := []string{u.SiteID.String()}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.AccessCount,
+			prometheus.GaugeValue,
+			float64(u.AccessCount),
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesSent,
+			prometheus.GaugeValue,
+			float64(u.BytesSent),
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.CacheMissBytesSent,
+			prometheus.GaugeValue,
+			float64(u.CacheMissBytesSent),
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.CacheHitRatio,
+			prometheus.GaugeValue,
+			u.CacheHitRatio,
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesCacheHitRatio,
+			prometheus.GaugeValue,
+			u.BytesCacheHitRatio,
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.Price,
+			prometheus.GaugeValue,
+			float64(u.Price),
+			labels...,
+		)
+	}
+}

--- a/collector/webaccel_test.go
+++ b/collector/webaccel_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019-2022 The sacloud/sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/webaccel-api-go"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyWebAccelClient struct {
+	sites []*webaccel.Site
+	usage *webaccel.MonthlyUsageResults
+	err   error
+}
+
+func (d *dummyWebAccelClient) Find(ctx context.Context) ([]*webaccel.Site, error) {
+	return d.sites, d.err
+}
+
+func (d *dummyWebAccelClient) Usage(ctx context.Context) (*webaccel.MonthlyUsageResults, error) {
+	return d.usage, d.err
+}
+
+func TestWebAccelCollector_Describe(t *testing.T) {
+	initLoggerAndErrors()
+	c := NewWebAccelCollector(context.Background(), testLogger, testErrors, &dummyWebAccelClient{})
+
+	descs := collectDescs(c)
+	require.Len(t, descs, 8)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	NoCollectorSIM                     bool `arg:"--no-collector.sim" help:"Disable the SIM collector"`
 	NoCollectorVPCRouter               bool `arg:"--no-collector.vpc-router" help:"Disable the VPCRouter collector"`
 	NoCollectorZone                    bool `arg:"--no-collector.zone" help:"Disable the Zone collector"`
+	NoCollectorWebAccel                bool `arg:"--no-collector.webaccel" help:"Disable the WebAccel collector"`
 }
 
 func InitConfig() (Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/sacloud/api-client-go v0.2.1
-	github.com/sacloud/iaas-api-go v1.3.1
+	github.com/sacloud/iaas-api-go v1.3.2
 	github.com/sacloud/iaas-service-go v1.3.1
 	github.com/sacloud/packages-go v0.0.5
+	github.com/sacloud/webaccel-api-go v1.1.3
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -274,12 +274,14 @@ github.com/sacloud/api-client-go v0.2.1 h1:jl02ZG6cM+mcH4eDYg0cxCFFuTOVTOjUCLYL4
 github.com/sacloud/api-client-go v0.2.1/go.mod h1:8fmYy5OpT3W8ltV5ZxF8evultNwKpduGN4YKmU9Af7w=
 github.com/sacloud/go-http v0.1.2 h1:a84HkeDHxDD1vIA6HiOT72a3fwwJueZBwuGP6zVtEJU=
 github.com/sacloud/go-http v0.1.2/go.mod h1:gvWaT8LFBFnSBFVrznOQXC62uad46bHZQM8w+xoH3eE=
-github.com/sacloud/iaas-api-go v1.3.1 h1:UmP9r4NNd1YucmeTzzJtsFsT9d/RYvJn2tP+HmC4yMk=
-github.com/sacloud/iaas-api-go v1.3.1/go.mod h1:CoqpRYBG2NRB5xfqTfZNyh2lVLKyLkE/HV9ISqmbhGc=
+github.com/sacloud/iaas-api-go v1.3.2 h1:03obrdVdv/bGHK9p6CV7Uzg+ot2gLsddUMevm9DDZqQ=
+github.com/sacloud/iaas-api-go v1.3.2/go.mod h1:CoqpRYBG2NRB5xfqTfZNyh2lVLKyLkE/HV9ISqmbhGc=
 github.com/sacloud/iaas-service-go v1.3.1 h1:ltMadQPUGzpSHD3k6XrqWy1XykIgZFseu/AA67qHjAI=
 github.com/sacloud/iaas-service-go v1.3.1/go.mod h1:2mkOWoEk8gdHuxShI6RLssw1g4Sd6vc92ErcNaL2vPk=
 github.com/sacloud/packages-go v0.0.5 h1:NXTQNyyp/3ugM4CANtLBJLejFESzfWu4GPUURN4NJrA=
 github.com/sacloud/packages-go v0.0.5/go.mod h1:XWMBSNHT9YKY3lCh6yJsx1o1RRQQGpuhNqJA6bSHdD4=
+github.com/sacloud/webaccel-api-go v1.1.3 h1:JKsjVL8U9QbzsEjMxqUzr+H7ni3vKVPhpdJeLkUy0ZQ=
+github.com/sacloud/webaccel-api-go v1.1.3/go.mod h1:GAmsQquhje9diSc/gAfVGYbavlD4S3KJCljOAxzAajU=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/platform/web_accel.go
+++ b/platform/web_accel.go
@@ -1,0 +1,49 @@
+// Copyright 2019-2022 The sakuracloud_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"context"
+
+	"github.com/sacloud/webaccel-api-go"
+)
+
+// WebAccelClient calls SakuraCloud webAccel API
+type WebAccelClient interface {
+	Find(ctx context.Context) ([]*webaccel.Site, error)
+	Usage(ctx context.Context) (*webaccel.MonthlyUsageResults, error)
+}
+
+func getWebAccelClient(caller webaccel.APICaller) WebAccelClient {
+	return &webAccelClient{
+		client: webaccel.NewOp(caller),
+	}
+}
+
+type webAccelClient struct {
+	client webaccel.API
+}
+
+func (c *webAccelClient) Find(ctx context.Context) ([]*webaccel.Site, error) {
+	res, err := c.client.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return res.Sites, nil
+}
+
+func (c *webAccelClient) Usage(ctx context.Context) (*webaccel.MonthlyUsageResults, error) {
+	return c.client.MonthlyUsage(ctx, "")
+}


### PR DESCRIPTION
closes #84 

ウェブアクセラレータ向けのメトリクスを追加する

- `webaccel_site_info`
- `webaccel_access_count`
- `webaccel_bytes_sent`
- `webaccel_cache_miss_bytes_sent`
- `webaccel_cache_hit_ratio`
- `webaccel_bytes_cache_hit_ratio`
- `webaccel_price`
- `webaccel_cert_expire`