### PR TITLE
billing APIをキャッシュする

### DIFF
--- a/platform/bill.go
+++ b/platform/bill.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	BILL_API_UPDATE_HOUR_JST   = 4
-	BILL_API_UPDATE_MINUTE_JST = 30
+	BillAPIUpdateHourJST   = 4
+	BillAPIUpdateMinuteJST = 30
 )
 
 // BillClient calls SakuraCloud bill API
@@ -115,7 +115,7 @@ func nextCacheExpiresAt() (time.Time, error) {
 
 	// 実行環境のタイムゾーンは不定のためJSTを基準にする
 	now := time.Now().In(jst)
-	expiresAt := time.Date(now.Year(), now.Month(), now.Day(), BILL_API_UPDATE_HOUR_JST, BILL_API_UPDATE_MINUTE_JST, 0, 0, jst)
+	expiresAt := time.Date(now.Year(), now.Month(), now.Day(), BillAPIUpdateHourJST, BillAPIUpdateMinuteJST, 0, 0, jst)
 	if now.Equal(expiresAt) || now.After(expiresAt) {
 		expiresAt = expiresAt.Add(24 * time.Hour)
 	}

--- a/platform/bill.go
+++ b/platform/bill.go
@@ -19,9 +19,15 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+)
+
+var (
+	BILL_API_UPDATE_HOUR_JST   = 4
+	BILL_API_UPDATE_MINUTE_JST = 30
 )
 
 // BillClient calls SakuraCloud bill API
@@ -30,16 +36,25 @@ type BillClient interface {
 }
 
 func getBillClient(caller iaas.APICaller) BillClient {
-	return &billClient{caller: caller}
+	return &billClient{
+		caller: caller,
+		cache:  *newCache(30 * time.Minute),
+	}
 }
 
 type billClient struct {
 	caller    iaas.APICaller
 	accountID types.ID
 	once      sync.Once
+	cache     cache
 }
 
 func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {
+	ca := c.cache.get()
+	if ca != nil {
+		return ca.(*iaas.Bill), nil
+	}
+
 	var err error
 	c.once.Do(func() {
 		var auth *iaas.AuthStatus
@@ -74,5 +89,33 @@ func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {
 			bill = b
 		}
 	}
+
+	n, err := nextCacheExpiresAt()
+	if err != nil {
+		return nil, err
+	}
+	c.cache.set(bill, n)
+
 	return bill, nil
+}
+
+// キャッシュの有効期限を算出する
+//
+// Billing APIは1日1回 AM4:30 (JST) にデータが更新される。
+// このため、現在時刻がAM4:30 (JST) よりも早ければ当日のAM4:30 (JST)、
+// 現在時刻がAM4:30 (JST) よりも遅ければ翌日のAM4:30 (JST) を有効期限として扱う。
+func nextCacheExpiresAt() (time.Time, error) {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// 実行環境のタイムゾーンは不定のためJSTを基準にする
+	now := time.Now().In(jst)
+	expiresAt := time.Date(now.Year(), now.Month(), now.Day(), BILL_API_UPDATE_HOUR_JST, BILL_API_UPDATE_MINUTE_JST, 0, 0, jst)
+	if now.Equal(expiresAt) || now.After(expiresAt) {
+		expiresAt = expiresAt.Add(24 * time.Hour)
+	}
+
+	return expiresAt, nil
 }

--- a/platform/bill.go
+++ b/platform/bill.go
@@ -94,7 +94,10 @@ func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.cache.set(bill, n)
+	err = c.cache.set(bill, n)
+	if err != nil {
+		return nil, err
+	}
 
 	return bill, nil
 }

--- a/platform/bill.go
+++ b/platform/bill.go
@@ -38,7 +38,7 @@ type BillClient interface {
 func getBillClient(caller iaas.APICaller) BillClient {
 	return &billClient{
 		caller: caller,
-		cache:  *newCache(30 * time.Minute),
+		cache:  newCache(30 * time.Minute),
 	}
 }
 
@@ -46,7 +46,7 @@ type billClient struct {
 	caller    iaas.APICaller
 	accountID types.ID
 	once      sync.Once
-	cache     cache
+	cache     *cache
 }
 
 func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {

--- a/platform/cache.go
+++ b/platform/cache.go
@@ -1,0 +1,60 @@
+package platform
+
+import (
+	"errors"
+	"time"
+)
+
+type cache struct {
+	cleanupInterval time.Duration
+	expiresAt       time.Time
+	item            any
+}
+
+func newCache(cleanupInterval time.Duration) *cache {
+	c := &cache{
+		cleanupInterval: cleanupInterval,
+	}
+	go c.startCleanup()
+
+	return c
+}
+
+func (c *cache) set(item any, expiresAt time.Time) error {
+	if item == nil {
+		return errors.New("item is not set")
+	}
+	if expiresAt.IsZero() {
+		return errors.New("expiresAt is not set")
+	}
+
+	c.item = item
+	c.expiresAt = expiresAt
+
+	return nil
+}
+
+func (c *cache) get() any {
+	if time.Now().After(c.expiresAt) {
+		return nil
+	}
+
+	return c.item
+}
+
+func (c *cache) clear() {
+	c.item = nil
+	c.expiresAt = time.Time{}
+}
+
+func (c *cache) startCleanup() {
+	t := time.NewTicker(c.cleanupInterval)
+	defer t.Stop()
+
+	for {
+		<-t.C
+		if !c.expiresAt.IsZero() && time.Now().After(c.expiresAt) {
+			c.clear()
+		}
+	}
+}

--- a/platform/cache.go
+++ b/platform/cache.go
@@ -17,7 +17,6 @@ func newCache(cleanupInterval time.Duration) *cache {
 	c := &cache{
 		cleanupInterval: cleanupInterval,
 	}
-	go c.cleanup()
 
 	return c
 }
@@ -48,19 +47,4 @@ func (c *cache) get() any {
 	}
 
 	return c.item
-}
-
-func (c *cache) cleanup() {
-	t := time.NewTicker(c.cleanupInterval)
-	defer t.Stop()
-
-	for {
-		<-t.C
-		c.mu.Lock()
-		if !c.expiresAt.IsZero() && time.Now().After(c.expiresAt) {
-			c.item = nil
-			c.expiresAt = time.Time{}
-		}
-		c.mu.Unlock()
-	}
 }

--- a/platform/cache_test.go
+++ b/platform/cache_test.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewCache(t *testing.T) {
+	cleanupInterval := 10 * time.Minute
+	cache := newCache(cleanupInterval)
+	if cache.cleanupInterval != cleanupInterval {
+		t.Errorf("expected cleanupInterval %v, got %v", cleanupInterval, cache.cleanupInterval)
+	}
+}
+
+func TestCache_Set(t *testing.T) {
+	cleanupInterval := 10 * time.Minute
+	cache := newCache(cleanupInterval)
+
+	item := "dummy_item"
+	expiresAt := time.Now().Add(1 * time.Hour)
+	err := cache.set(item, expiresAt)
+	if err != nil {
+		t.Error(err)
+	}
+	if cache.item != item {
+		t.Errorf("item %v, got %v", item, cache.item)
+	}
+	if cache.expiresAt != expiresAt {
+		t.Errorf("expiresAt %v, got %v", expiresAt, cache.expiresAt)
+	}
+}
+
+func TestCache_Get_ItemNotExpired(t *testing.T) {
+	cleanupInterval := 10 * time.Minute
+	cache := newCache(cleanupInterval)
+
+	item := "dummy_item"
+	expiresAt := time.Now().Add(1 * time.Hour)
+	err := cache.set(item, expiresAt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	cachedItem := cache.get()
+	if cachedItem != item {
+		t.Errorf("cachedItem %v, got %v", item, cachedItem)
+	}
+}
+
+func TestCache_Get_ItemExpired(t *testing.T) {
+	cleanupInterval := 1 * time.Second
+	cache := newCache(cleanupInterval)
+
+	item := "dummy_item"
+	expiresAt := time.Now().Add(1 * time.Second)
+	err := cache.set(item, expiresAt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// キャッシュの期限切れと削除が行われるのを待つ
+	time.Sleep(2 * time.Second)
+
+	cachedItem := cache.get()
+	if cachedItem != nil {
+		t.Errorf("cached item not cleared, got %v", cachedItem)
+	}
+	if !cache.expiresAt.IsZero() {
+		t.Errorf("expiresAt not cleared, got %v", cache.expiresAt)
+	}
+}

--- a/platform/cache_test.go
+++ b/platform/cache_test.go
@@ -66,7 +66,4 @@ func TestCache_Get_ItemExpired(t *testing.T) {
 	if cachedItem != nil {
 		t.Errorf("cached item not cleared, got %v", cachedItem)
 	}
-	if !cache.expiresAt.IsZero() {
-		t.Errorf("expiresAt not cleared, got %v", cache.expiresAt)
-	}
 }


### PR DESCRIPTION
## 背景
sakuracaloud_exporterの `sakuracloud_bill_amount` メトリクスとして、さくらのクラウドの請求情報が提供されます。
この請求情報はsakuracaloud_exporterが [さくらのクラウド API](https://manual.sakura.ad.jp/cloud-api/1.1/bill/index.html) にリクエストし、情報を取得することで実現しています。

さくらのクラウド請求情報は1日1回のバッチ処理で更新されるため、他のメトリクスとは異なり細かい間隔で頻繁にAPIリクエストをする必要がありません。このためsakuracaloud_exporter内でAPIレスポンスをキャッシュして、無駄なAPIリクエストを減らすようにします。

## 設計
- Redis/Memcached等の外部キャッシュに頼らないようにしin memoryのキャッシュとする
  - つまりsakuracaloud_exporterプロセスが再起動した場合はキャッシュが消えてしまうが、現状のユースケースでは問題ないため許容する
- 既存のニーズでは複数のキャッシュを持つ必要がないため、キャッシュキーを管理せず単一の値をキャッシュする
  - 将来的に必要であればキャッシュキーを持って複数のキャッシュを持てるように変更する余地はある
- キャッシュ利用者はキャッシュデータ・有効期限日時・期限切れのチェック間隔の3つを指定して利用する
  - 有効期限をすぎるとキャッシュはクリアされる

## 動作確認
golangのデバッグモードで動作確認をしました。

### 1. プロセス起動直後に `/metrics` にHTTPアクセス

- [x] キャッシュが存在しないことを確認
<img width="884" alt="スクリーンショット 2024-10-25 14 26 56" src="https://github.com/user-attachments/assets/d797febb-df23-4d7a-9cf7-b57ed9fe7d1f">

- [x] billing APにIリクエストが行われたことを確認
- [x] メトリクスが正しく取得できることを確認

### 2. 再度  `/metrics` にHTTPアクセス

- [x] キャッシュが存在することを確認
<img width="875" alt="スクリーンショット_2024-10-25_14_30_07" src="https://github.com/user-attachments/assets/f64d16e5-da8b-4eb7-a322-8f1985b07af7">


- [x]  billing APにIリクエストが行われ**ない**ことを確認
- [x] メトリクスが正しく取得できることを確認