### PR TITLE
coupon APIをキャッシュする

### DIFF
--- a/platform/bill.go
+++ b/platform/bill.go
@@ -90,7 +90,7 @@ func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {
 		}
 	}
 
-	n, err := nextCacheExpiresAt()
+	n, err := c.nextCacheExpiresAt()
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (c *billClient) Read(ctx context.Context) (*iaas.Bill, error) {
 // Billing APIは1日1回 AM4:30 (JST) にデータが更新される。
 // このため、現在時刻がAM4:30 (JST) よりも早ければ当日のAM4:30 (JST)、
 // 現在時刻がAM4:30 (JST) よりも遅ければ翌日のAM4:30 (JST) を有効期限として扱う。
-func nextCacheExpiresAt() (time.Time, error) {
+func (c *billClient) nextCacheExpiresAt() (time.Time, error) {
 	jst, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		return time.Time{}, err


### PR DESCRIPTION
## 背景・設計
https://github.com/sacloud/sakuracloud_exporter/pull/202 と同様となります。

## 動作確認
golangのデバッグモードで動作確認をしました。

### 1. プロセス起動直後に `/metrics` にHTTPアクセス

- [x] キャッシュが存在しないことを確認
<img width="657" alt="スクリーンショット 2024-10-25 16 09 08" src="https://github.com/user-attachments/assets/99939eb3-516a-48ac-bd0f-d4fac8604a68">

- [x] coupon APにリクエストが行われたことを確認
- [x] メトリクスが正しく取得できることを確認

### 2. 再度  `/metrics` にHTTPアクセス

- [x] キャッシュが存在することを確認
<img width="678" alt="スクリーンショット 2024-10-25 16 09 48" src="https://github.com/user-attachments/assets/00ca7506-0957-4082-8068-f92481b98a9e">

- [x]  coupon APにリクエストが行われ**ない**ことを確認
- [x] メトリクスが正しく取得できることを確認