### PR TITLE
ProxyLBCollectorのcert_info, cert_expireのテストを実装

### DIFF
--- a/collector/proxy_lb_test.go
+++ b/collector/proxy_lb_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO test certificates(common name and expire date)
-
 type dummyProxyLBClient struct {
 	find       []*iaas.ProxyLB
 	findErr    error
@@ -137,11 +135,82 @@ func TestProxyLBCollector_Collect(t *testing.T) {
 				},
 				cert: &iaas.ProxyLBCertificates{
 					PrimaryCert: &iaas.ProxyLBPrimaryCert{
-						ServerCertificate:       "",
-						IntermediateCertificate: "",
-						PrivateKey:              "",
-						CertificateEndDate:      time.Time{},
-						CertificateCommonName:   "",
+						ServerCertificate: `-----BEGIN CERTIFICATE-----
+MIIDzTCCArWgAwIBAgIUZllLmMvTzLYyCQPqmnmt8zfOdVowDQYJKoZIhvcNAQEL
+BQAwdjELMAkGA1UEBhMCSlAxDjAMBgNVBAgMBVRva3lvMREwDwYDVQQHDAhTaGlu
+anVrdTEaMBgGA1UECgwRVGVzdCBPcmdhbml6YXRpb24xEjAQBgNVBAsMCVRlc3Qg
+VW5pdDEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjQxMjIwMDcwNTUyWhcNMjUx
+MjIwMDcwNTUyWjB2MQswCQYDVQQGEwJKUDEOMAwGA1UECAwFVG9reW8xETAPBgNV
+BAcMCFNoaW5qdWt1MRowGAYDVQQKDBFUZXN0IE9yZ2FuaXphdGlvbjESMBAGA1UE
+CwwJVGVzdCBVbml0MRQwEgYDVQQDDAtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBANhpoUrynlFZDXVVlr7XYYUYRVRnPDNsHGKopF81
+6V63WosAJpIz+8biFFA+OfwX2b/VX2VsE4Nakg5TGnxtEe+LFi5bphrbGmLFsxoT
+8IMFu4qEKrybI+61jdkvhDWd5D82dohkE4poOvGePqrEhECREWQ17d5Oqc9cj39d
+rerBfY2j9k+w0PxYtdQo7+FrBfQBOxMmDVqY1umTZTswfTn8sXsugqn4UrHrBtYd
+O1/MeFsx4c63n48D5DepquvBmwnTa9ccnHbrdIItWs7BwgJKbDt7NJ1rtTED/1G9
+xnk/pld2iPySqGLlPRyqETtMNcdyx3KfkOnH7Q5H17Wi1kMCAwEAAaNTMFEwHQYD
+VR0OBBYEFO0w5+4Hp1fkxLAThWyLF5v4sC61MB8GA1UdIwQYMBaAFO0w5+4Hp1fk
+xLAThWyLF5v4sC61MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB
+AKMEfy6bA0/d7yNTEXssPpEhC7/XolkAqKntl741TQ0mgJAkgeUGIfFkFNioCeQc
+m3Aqam6IsMyHcZwo9gJR4KnE02N+jQpLJbDw8ym2BwCpF9g43x5K9qzvFEml4Idg
+nq9UP0T4Yz1eKvCmVCm8cApVqr02TYnYMg9Oo3QE0giPIEHdG0mDuWM46eDAzoLL
+8ib9EPnmyswhfNzSZyoH5nNV8137VOwPGtcBAg8fmdO+hmOVgEU5OGxz3U26toi5
+yfHUC+O5jhCLSTAJwd2RWeCMEcN9FVI1IaGZV2WxrbXC+/5qZTjSvdvrmVbVAAd2
+ybZBwFTVijAdTHYmC1VNSxQ=
+-----END CERTIFICATE-----`,
+						IntermediateCertificate: `-----BEGIN CERTIFICATE-----
+MIID0jCCArqgAwIBAgIUcCPU6qCiTPDVQ1LW9bePo+PMQKEwDQYJKoZIhvcNAQEL
+BQAwdjELMAkGA1UEBhMCSlAxDjAMBgNVBAgMBVRva3lvMREwDwYDVQQHDAhTaGlu
+anVrdTEaMBgGA1UECgwRVGVzdCBPcmdhbml6YXRpb24xEjAQBgNVBAsMCVRlc3Qg
+VW5pdDEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjQxMjIwMDcwNjE0WhcNMjUx
+MjIwMDcwNjE0WjCBizELMAkGA1UEBhMCSlAxDjAMBgNVBAgMBVRva3lvMREwDwYD
+VQQHDAhTaGluanVrdTEaMBgGA1UECgwRVGVzdCBPcmdhbml6YXRpb24xGjAYBgNV
+BAsMEUludGVybWVkaWF0ZSBVbml0MSEwHwYDVQQDDBhpbnRlcm1lZGlhdGUuZXhh
+bXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDoW7sb/ahy
+PdoC+duRXjGoNp2caCTS02JcxMjFzE3yKj/p+SFNr7ufNTxMRIGcFLzmgYHRo0C/
+MWYXPF5aKwhZYtln2ur87NErrZfPT/8xBdY/H5fJOpKyBB/ByfnIeYgFBBkZRCfT
+Dytu/WOZENTsd1JAiirzM3xXvlopwiICsQ3JyMNfcbvYPQqLIY6Aynj1S5+aJDpg
+x/F+n1r7Ji1egpfblaIMeX0Q0goDLNEfGESzFbbqFzs5OTBpexknbST9yNH6Fb9u
+Tv4MEhjDsjYkDvjIV1QN0PH8R63toclcp2P3bMOxczkds5EKSVMkS5Bp2+rYNbK+
+Hgpdt6wR5U/rAgMBAAGjQjBAMB0GA1UdDgQWBBSqCuNjLuEFj02uRKSYSQvzk9sy
+KzAfBgNVHSMEGDAWgBTtMOfuB6dX5MSwE4Vsixeb+LAutTANBgkqhkiG9w0BAQsF
+AAOCAQEAfJT2uxSjAOfClYrj9atjxDz8EVaELLNTZEL1QNBqFs1nD82MHRQs2Fyr
+mMwaeIlDyIO44kyL9A/jFFi9yQP5li0qCTNQZu7bz1PWhsvnfJCJEQkkRLS9X8ZL
+b03jOlsWrse0dFSY3wHJk/SmBUnO/VAdx6wZu/jf6mxar48nSm+3lxvRKNRutiPZ
+96wjwUKr1ExOz3Ju2hf+/akUn1byb4hgVsF17TCy6zP7rSfdOknhuKwNc0KQLhsL
+PLS5Ur7caLG/BVSX/kYVreYeHVw7yU5BWL9iAktSmckC+CMk5iw9XAE152kK2JUH
+la0yTEo/WpPQtAxgXuxLy5XiiLSfNQ==
+-----END CERTIFICATE-----`,
+						PrivateKey: `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDYaaFK8p5RWQ11
+VZa+12GFGEVUZzwzbBxiqKRfNelet1qLACaSM/vG4hRQPjn8F9m/1V9lbBODWpIO
+Uxp8bRHvixYuW6Ya2xpixbMaE/CDBbuKhCq8myPutY3ZL4Q1neQ/NnaIZBOKaDrx
+nj6qxIRAkRFkNe3eTqnPXI9/Xa3qwX2No/ZPsND8WLXUKO/hawX0ATsTJg1amNbp
+k2U7MH05/LF7LoKp+FKx6wbWHTtfzHhbMeHOt5+PA+Q3qarrwZsJ02vXHJx263SC
+LVrOwcICSmw7ezSda7UxA/9RvcZ5P6ZXdoj8kqhi5T0cqhE7TDXHcsdyn5Dpx+0O
+R9e1otZDAgMBAAECggEAAgSmKOqZ+FySErnhcIErWyWOoUq0gIRDFYEeG0yHkxxh
+n0c5P4bK6SAQRsP1ys3heCJXbpIzR7fPVzaGL4qILsmHbkI+NSToROs0EDZcY/8T
+MH0ACwc6rri0YcX0KoMrmZKlSKtU6qcDLwql6fYa3PadXhJfWAHiyoNsoShF/W5G
+cVieewukl1SVg/k5zIggIL/TZZ5ac8gSffrbeW+D4/0eKqWK2ZifeIF+XAxWGFMx
+VSIQKsWSJy75rp5YmwIW12zvaX9PGClDQE55tha3U8N0/a49IVbr67D/SxeHhsPK
+dVxIyVqK69jfq8nxnpk/NnhkHi7QFWw8g8JapY9lvQKBgQD0N1Dw8Wbj6qh3Ilo/
+aF1jGDeWsF/1PcnuoFom85Bu4YDAT92uzxPT/is8ceJcL90lEVSn3EdDM30oJGr0
+tONDKN1kB4iIayt/dBsjWCfOPW0jvJHjSXa4PTeqdxWUIrA5f5YklTbLodfA0EQq
+RMDhXgEMujpDwCW9wbWXxiRP1wKBgQDi2t7/Fg0zzLX21YUQN3Y3nDVezoc73ph6
+qNvsjAuRuthyjzLhM2zhFTiw9mdaDu7XKo/1ZCHse3JEKz+YZVn5I05XNxYrTkVD
+xhHuEG1grxqKjMcMq4yUiUy4yY68TX3PEy9JrYV+n8S75hNaaf/I+fsm5c1rOP9o
+5U4DX/FPdQKBgQCjPta8OKGueI1kFXJ+MCU8uFNwRzXdmRACku2wW9+QPuzxoHFv
+CL0YWC5OmVHWjaglvw/3pSd9pE1lJ/LW4JOJsSdMVjzN89V/vPznA2aYVjc+TC64
+38KcJU+wgynJe+aQiNi0W4nlVKoEGTN3jb3g6BWLjHCmGSshTPs2GRzswQKBgD3h
+gFTK2h0YKUbEpcBvsJKozLIo2iDNroA/EYasCPfepO5S+4kMsxWO6WD0Rer+Cc6t
+sIk6oDpWziukNHvIocthAxytTSHQ/vnmzLtIxd1Kxo2mqyFcpkNaVJBPgt0AsmHL
+FOofKDwLLuomb38JTRmwfv70Tp2B9cHSUv5+rF+FAoGBALW3gmfRI3+Ax1scn5QQ
+CIKJ5Fd6mrntdmXkW1NWz/DR0a04wSB/eiCz8J8KGfx78/S44JUyDZQq6S+1JMzL
++Cv2dgc5wG2swzUeTgA/0khXuJ6r17zLDIolXnTfXQ77y6dW/li6qUJyfTCFXe+A
+9Ncpwbw8KmFw9wHm5eVAk/nz
+-----END PRIVATE KEY-----`,
+						CertificateEndDate:    time.Now().AddDate(1, 0, 0),
+						CertificateCommonName: "example.com",
 					},
 				},
 				monitor: &iaas.MonitorConnectionValue{
@@ -217,6 +286,24 @@ func TestProxyLBCollector_Collect(t *testing.T) {
 						"id":   "101",
 						"name": "proxylb",
 					}, monitorTime),
+				},
+				{
+					desc: c.CertificateInfo,
+					metric: createGaugeMetric(1, map[string]string{
+						"id":          "101",
+						"name":        "proxylb",
+						"cert_index":  "0",
+						"common_name": "example.com",
+						"issuer_name": "example.com",
+					}),
+				},
+				{
+					desc: c.CertificateExpireDate,
+					metric: createGaugeMetric(float64(time.Now().AddDate(1, 0, 0).Unix())*1000, map[string]string{
+						"id":         "101",
+						"name":       "proxylb",
+						"cert_index": "0",
+					}),
 				},
 			},
 		},


### PR DESCRIPTION
## 背景
https://github.com/sacloud/sakuracloud_exporter/pull/212 にてProxyLBCollectorで利用しているcryptoのアップデートが来ています。

ProxyLBCollectorにおいてcryptoは証明書ののパース処理に利用されており、cyptoのアップデート前に現在のバージョンで動作するテストを実装します。
- https://github.com/sacloud/sakuracloud_exporter/blob/64b58ad5e667832d396835f9f965f0424168756b/collector/proxy_lb.go#L289
- https://github.com/sacloud/sakuracloud_exporter/blob/64b58ad5e667832d396835f9f965f0424168756b/collector/proxy_lb.go#L318

## 変更点
ProxyLBCollectorのcert_info, cert_expireのテストを実装しました。証明書に関してはテスト用のオレオレ証明書を作成して利用しました。

## 動作確認
- [x] CIが通ること