### PR TITLE
VPCルータにおいて任意の位置にNICを作成する場合を考慮する

### DIFF
--- a/collector/vpc_router.go
+++ b/collector/vpc_router.go
@@ -414,10 +414,6 @@ func getInterfaceByIndex(interfaces []*iaas.VPCRouterInterfaceSetting, index int
 }
 
 func (c *VPCRouterCollector) nicLabels(vpcRouter *platform.VPCRouter, index int) []string {
-	if len(vpcRouter.Interfaces) <= index {
-		return nil
-	}
-
 	var vip, ipaddress1, ipaddress2 string
 	nwMaskLen := ""
 


### PR DESCRIPTION


<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

従来はlen(vpcRouter.Interfaces) <= indexのような比較をしていたが、indexはユーザーが任意に選択可能でありNICの総数と関連しない。 このため一部のチェックロジックが上手く動かずエラーが起きていた。

このPRでは問題のあるチェックロジックを除去することでこの問題に対応した。
チェックロジックがなくとも後続処理でindexのハンドリングをしているため除去しても問題ない。

### ドキュメントの変更は必要ですか？

no