### PR TITLE
chore: Release notes を見やすくします

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,14 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: 🚀 Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: 📦 Dependency Updates
+      labels:
+        - dependencies
+


### PR DESCRIPTION
Dependabot とそれ以外を分離して releases notes を見やすくします。

https://github.com/sacloud/packer-plugin-sakuracloud/pull/311 と同様です