### PR TITLE
Restrict test workflow permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
 env:
   GOPROXY: https://proxy.golang.org
 jobs:


### PR DESCRIPTION
## Summary
- explicitly limit the test workflow token to read-only repository contents
- prevent inherited repository or organization write permissions from applying

## Validation
- `make lint-action`